### PR TITLE
CLOUDP-58568: Deleting alert configs is not asking for confirmation

### DIFF
--- a/internal/cli/atlas_alert_config_delete.go
+++ b/internal/cli/atlas_alert_config_delete.go
@@ -46,18 +46,21 @@ func AtlasAlertConfigDeleteBuilder() *cobra.Command {
 	opts := &atlasAlertConfigDeleteOpts{
 		globalOpts: newGlobalOpts(),
 		deleteOpts: &deleteOpts{
-			successMessage: "Alert Config '%s' deleted\n",
-			failMessage:    "Alert Config not deleted",
+			successMessage: "Alert config '%s' deleted\n",
+			failMessage:    "Alert config not deleted",
 		},
 	}
 	cmd := &cobra.Command{
 		Use:     "delete [id]",
-		Short:   "Delete an Atlas Alert Config.",
+		Short:   "Delete an alert config.",
 		Aliases: []string{"rm", "Delete", "Remove"},
 		Args:    cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.init(); err != nil {
+				return err
+			}
 			opts.entry = args[0]
-			return opts.init()
+			return opts.Confirm()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-58568](https://jira.mongodb.org/browse/CLOUDP-58568)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

We need to start testing stdio