### PR TITLE
CLOUDP-59777: Use profile project id for listing clusters

### DIFF
--- a/internal/cli/cloud_manager_clusters_list.go
+++ b/internal/cli/cloud_manager_clusters_list.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	om "github.com/mongodb/go-client-mongodb-ops-manager/opsmngr"
-	"github.com/mongodb/mongocli/internal/config"
 	"github.com/mongodb/mongocli/internal/convert"
 	"github.com/mongodb/mongocli/internal/description"
 	"github.com/mongodb/mongocli/internal/flags"
@@ -51,7 +50,7 @@ func cloudManagerClustersListRun(opts *cloudManagerClustersListOpts) (interface{
 	var result interface{}
 	var err error
 
-	if opts.projectID == "" && config.Service() == config.OpsManagerService {
+	if opts.ProjectID() == "" {
 		result, err = opts.store.ListAllProjectClusters()
 
 	} else {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-59777](https://jira.mongodb.org/browse/CLOUDP-59777)

Had this issue the other day as I have a project id set in my profile and was trying against om4.2 (4.2 doesn't have the all clusters feature)
