### PR TITLE
CLOUDP-61595: mongocli ops-manager servers list does not validate project id requirement

### DIFF
--- a/internal/cli/ops_manager_servers_list.go
+++ b/internal/cli/ops_manager_servers_list.go
@@ -31,7 +31,7 @@ type opsManagerServersListOpts struct {
 	store store.AgentLister
 }
 
-func (opts *opsManagerServersListOpts) init() error {
+func (opts *opsManagerServersListOpts) initStore() error {
 	var err error
 	opts.store, err = store.New()
 	return err
@@ -56,7 +56,7 @@ func OpsManagerAgentsListBuilder() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Short:   description.ListServer,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.init()
+			return opts.PreRunE(opts.initStore)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-61595](https://jira.mongodb.org/browse/CLOUDP-61595)

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This was a missed file from the refactor to centralise project id validations