### PR TITLE
CLOUDP-65292: Enable deleteAfter as an option when create IP whitelist entry

### DIFF
--- a/e2e/atlas/whitelist_test.go
+++ b/e2e/atlas/whitelist_test.go
@@ -109,7 +109,7 @@ func TestWhitelist(t *testing.T) {
 			whitelistEntity,
 			"create",
 			entry,
-			"--deleteAfter="+time.Now().Add(time.Minute * time.Duration(5)).Format(time.RFC3339),
+			"--deleteAfter="+time.Now().Add(time.Minute*time.Duration(5)).Format(time.RFC3339),
 			"--comment=test")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()

--- a/e2e/atlas/whitelist_test.go
+++ b/e2e/atlas/whitelist_test.go
@@ -109,7 +109,7 @@ func TestWhitelist(t *testing.T) {
 			whitelistEntity,
 			"create",
 			entry,
-			"--deleteAfter="+time.Now().AddDate(0, 0, 1).Format(time.RFC3339),
+			"--deleteAfter="+time.Now().Add(time.Minute * time.Duration(5)).Format(time.RFC3339),
 			"--comment=test")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()

--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/alerts"
 	"github.com/mongodb/mongocli/internal/cli/cloudbackup"
 	"github.com/mongodb/mongocli/internal/cli/events"
+	"github.com/mongodb/mongocli/internal/cli/whitelist"
 	"github.com/mongodb/mongocli/internal/description"
 	"github.com/mongodb/mongocli/internal/validate"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func Builder() *cobra.Command {
 	}
 	cmd.AddCommand(ClustersBuilder())
 	cmd.AddCommand(DBUsersBuilder())
-	cmd.AddCommand(WhitelistBuilder())
+	cmd.AddCommand(whitelist.Builder())
 	cmd.AddCommand(alerts.Builder())
 	cmd.AddCommand(cloudbackup.Builder())
 	cmd.AddCommand(events.Builder())

--- a/internal/cli/whitelist/create.go
+++ b/internal/cli/whitelist/create.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	atlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
@@ -32,21 +32,22 @@ const (
 	awsSecurityGroup = "awsSecurityGroup"
 )
 
-type WhitelistCreateOpts struct {
+type CreateOpts struct {
 	cli.GlobalOpts
-	entry     string
-	entryType string
-	comment   string
-	store     store.ProjectIPWhitelistCreator
+	entry       string
+	entryType   string
+	comment     string
+	deleteAfter string
+	store       store.ProjectIPWhitelistCreator
 }
 
-func (opts *WhitelistCreateOpts) initStore() error {
+func (opts *CreateOpts) initStore() error {
 	var err error
 	opts.store, err = store.New(config.Default())
 	return err
 }
 
-func (opts *WhitelistCreateOpts) Run() error {
+func (opts *CreateOpts) Run() error {
 	entry := opts.newWhitelist()
 	result, err := opts.store.CreateProjectIPWhitelist(entry)
 
@@ -57,10 +58,11 @@ func (opts *WhitelistCreateOpts) Run() error {
 	return json.PrettyPrint(result)
 }
 
-func (opts *WhitelistCreateOpts) newWhitelist() *atlas.ProjectIPWhitelist {
+func (opts *CreateOpts) newWhitelist() *atlas.ProjectIPWhitelist {
 	projectIPWhitelist := &atlas.ProjectIPWhitelist{
-		GroupID: opts.ConfigProjectID(),
-		Comment: opts.comment,
+		GroupID:         opts.ConfigProjectID(),
+		Comment:         opts.comment,
+		DeleteAfterDate: opts.deleteAfter,
 	}
 	switch opts.entryType {
 	case cidrBlock:
@@ -73,9 +75,9 @@ func (opts *WhitelistCreateOpts) newWhitelist() *atlas.ProjectIPWhitelist {
 	return projectIPWhitelist
 }
 
-// mongocli atlas whitelist(s) create <entry> --type cidrBlock|ipAddress [--comment comment] [--projectId projectId]
-func WhitelistCreateBuilder() *cobra.Command {
-	opts := &WhitelistCreateOpts{}
+// mongocli atlas whitelist(s) create <entry> --type cidrBlock|ipAddress|awsSecurityGroup [--comment comment] [--projectId projectId]
+func CreateBuilder() *cobra.Command {
+	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create <entry>",
 		Short: description.CreateWhitelist,
@@ -92,6 +94,7 @@ func WhitelistCreateBuilder() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.entryType, flag.Type, ipAddress, usage.WhitelistType)
 	cmd.Flags().StringVar(&opts.comment, flag.Comment, "", usage.Comment)
+	cmd.Flags().StringVar(&opts.comment, flag.DeleteAfter, "", usage.DeleteAfter)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/whitelist/create_test.go
+++ b/internal/cli/whitelist/create_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	"testing"
@@ -30,7 +30,7 @@ func TestWhitelistCreate_Run(t *testing.T) {
 
 	var expected []mongodbatlas.ProjectIPWhitelist
 
-	createOpts := &WhitelistCreateOpts{
+	createOpts := &CreateOpts{
 		entry:     "37.228.254.100",
 		entryType: ipAddress,
 		store:     mockStore,

--- a/internal/cli/whitelist/delete_test.go
+++ b/internal/cli/whitelist/delete_test.go
@@ -12,35 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	"testing"
 
+	"github.com/mongodb/mongocli/internal/cli"
+
 	"github.com/golang/mock/gomock"
-	"github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
 	"github.com/mongodb/mongocli/internal/mocks"
 )
 
-func TestWhitelistList_Run(t *testing.T) {
+func TestWhitelistDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockStore := mocks.NewMockProjectIPWhitelistLister(ctrl)
+	mockStore := mocks.NewMockProjectIPWhitelistDeleter(ctrl)
 
 	defer ctrl.Finish()
 
-	var expected []mongodbatlas.ProjectIPWhitelist
-
-	listOpts := &WhitelistListOpts{
+	deleteOpts := &DeleteOpts{
+		DeleteOpts: &cli.DeleteOpts{
+			Confirm: true,
+			Entry:   "test",
+		},
 		store: mockStore,
 	}
 
 	mockStore.
 		EXPECT().
-		ProjectIPWhitelists(listOpts.ProjectID, listOpts.NewListOptions()).
-		Return(expected, nil).
+		DeleteProjectIPWhitelist(deleteOpts.ProjectID, deleteOpts.Entry).
+		Return(nil).
 		Times(1)
 
-	err := listOpts.Run()
+	err := deleteOpts.Run()
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}

--- a/internal/cli/whitelist/describe_test.go
+++ b/internal/cli/whitelist/describe_test.go
@@ -12,38 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	"testing"
 
-	"github.com/mongodb/mongocli/internal/cli"
-
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
 	"github.com/mongodb/mongocli/internal/mocks"
 )
 
-func TestWhitelistDelete_Run(t *testing.T) {
+func TestWhitelistDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockStore := mocks.NewMockProjectIPWhitelistDeleter(ctrl)
+	mockStore := mocks.NewMockProjectIPWhitelistDescriber(ctrl)
 
 	defer ctrl.Finish()
 
-	deleteOpts := &WhitelistDeleteOpts{
-		DeleteOpts: &cli.DeleteOpts{
-			Confirm: true,
-			Entry:   "test",
-		},
+	expected := &mongodbatlas.ProjectIPWhitelist{}
+
+	describeOpts := &DescribeOpts{
+		name:  "test",
 		store: mockStore,
 	}
 
 	mockStore.
 		EXPECT().
-		DeleteProjectIPWhitelist(deleteOpts.ProjectID, deleteOpts.Entry).
-		Return(nil).
+		IPWhitelist(describeOpts.ProjectID, describeOpts.name).
+		Return(expected, nil).
 		Times(1)
 
-	err := deleteOpts.Run()
+	err := describeOpts.Run()
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}

--- a/internal/cli/whitelist/list.go
+++ b/internal/cli/whitelist/list.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package atlas
+package whitelist
 
 import (
 	"github.com/mongodb/mongocli/internal/cli"
@@ -24,19 +24,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type WhitelistListOpts struct {
+type ListOpts struct {
 	cli.GlobalOpts
 	cli.ListOpts
 	store store.ProjectIPWhitelistLister
 }
 
-func (opts *WhitelistListOpts) initStore() error {
+func (opts *ListOpts) initStore() error {
 	var err error
 	opts.store, err = store.New(config.Default())
 	return err
 }
 
-func (opts *WhitelistListOpts) Run() error {
+func (opts *ListOpts) Run() error {
 	listOpts := opts.NewListOptions()
 	result, err := opts.store.ProjectIPWhitelists(opts.ConfigProjectID(), listOpts)
 
@@ -48,8 +48,8 @@ func (opts *WhitelistListOpts) Run() error {
 }
 
 // mongocli atlas whitelist(s) list --projectId projectId [--page N] [--limit N]
-func WhitelistListBuilder() *cobra.Command {
-	opts := &WhitelistListOpts{}
+func ListBuilder() *cobra.Command {
+	opts := &ListOpts{}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   description.ListWhitelist,

--- a/internal/cli/whitelist/list_test.go
+++ b/internal/cli/whitelist/list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	"testing"
@@ -22,26 +22,25 @@ import (
 	"github.com/mongodb/mongocli/internal/mocks"
 )
 
-func TestWhitelistDescribe_Run(t *testing.T) {
+func TestWhitelistList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockStore := mocks.NewMockProjectIPWhitelistDescriber(ctrl)
+	mockStore := mocks.NewMockProjectIPWhitelistLister(ctrl)
 
 	defer ctrl.Finish()
 
-	expected := &mongodbatlas.ProjectIPWhitelist{}
+	var expected []mongodbatlas.ProjectIPWhitelist
 
-	describeOpts := &WhitelistDescribeOpts{
-		name:  "test",
+	listOpts := &ListOpts{
 		store: mockStore,
 	}
 
 	mockStore.
 		EXPECT().
-		IPWhitelist(describeOpts.ProjectID, describeOpts.name).
+		ProjectIPWhitelists(listOpts.ProjectID, listOpts.NewListOptions()).
 		Return(expected, nil).
 		Times(1)
 
-	err := describeOpts.Run()
+	err := listOpts.Run()
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}

--- a/internal/cli/whitelist/whitelist.go
+++ b/internal/cli/whitelist/whitelist.go
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package atlas
+package whitelist
 
 import (
 	"github.com/mongodb/mongocli/internal/description"
 	"github.com/spf13/cobra"
 )
 
-func WhitelistBuilder() *cobra.Command {
+func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whitelist",
 		Short: description.Whitelist,
 	}
-	cmd.AddCommand(WhitelistDescribeBuilder())
-	cmd.AddCommand(WhitelistListBuilder())
-	cmd.AddCommand(WhitelistCreateBuilder())
-	cmd.AddCommand(WhitelistDeleteBuilder())
+	cmd.AddCommand(DescribeBuilder())
+	cmd.AddCommand(ListBuilder())
+	cmd.AddCommand(CreateBuilder())
+	cmd.AddCommand(DeleteBuilder())
 
 	return cmd
 }

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -50,6 +50,7 @@ const (
 	Mechanisms                      = "mechanisms"                      // Mechanisms flag
 	Type                            = "type"                            // Type flag
 	Comment                         = "comment"                         // Comment flag
+	DeleteAfter                     = "deleteAfter"                     // DeleteAfter flag
 	Until                           = "until"                           // Until flag
 	Page                            = "page"                            // Page flag
 	Limit                           = "limit"                           // Limit flag

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -35,6 +35,7 @@ const (
 	Period                          = "Duration in ISO 8601 notation that specifies how far back in the past to retrieve measurements."
 	Roles                           = "User's roles and the databases or collections on which the roles apply."
 	Comment                         = "Optional description or comment for the entry."
+	DeleteAfter                     = "ISO-8601-formatted UTC date after which Atlas removes the entry from the whitelist."
 	Force                           = "Don't ask for confirmation."
 	Email                           = "User’s email address."
 	LogOut                          = "Optional output filename, if none given will use the log name."
@@ -124,7 +125,7 @@ For use only with download restore jobs.`
 	Mechanisms = `Authentication mechanism. 
 Valid values: SCRAM-SHA-1|SCRAM-SHA-256`
 	WhitelistType = `Type of whitelist entry.
-Valid values: cidrBlock|ipAddress`
+Valid values: cidrBlock|ipAddress|awsSecurityGroup`
 	Service = `Type of MongoDB service.
 Valid values: cloud|cloud-manager|ops-manager`
 	Provider = `Name of your cloud service provider.


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-65292](https://jira.mongodb.org/browse/CLOUDP-65292)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
