### PR TITLE
CLOUDP-66132: use any available profile

### DIFF
--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -80,7 +80,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
 	// config commands
 	rootCmd.AddCommand(cliconfig.Builder())
 	// Atlas commands
@@ -96,14 +95,23 @@ func init() {
 
 	cobra.EnableCommandSorting = false
 
-	profile := rootCmd.PersistentFlags().StringP(flag.Profile, flag.ProfileShort, config.DefaultProfile, usage.Profile)
-	config.SetName(profile)
+	profile := rootCmd.PersistentFlags().StringP(flag.Profile, flag.ProfileShort, "", usage.Profile)
+	cobra.OnInitialize(func() {
+		initConfig(profile)
+	})
 }
 
 // initConfig reads in config file and ENV variables if set.
-func initConfig() {
+func initConfig(profileName *string) {
 	if err := config.Load(); err != nil {
 		log.Fatalf("Error loading config: %v", err)
+	}
+
+	availableProfiles := config.List()
+	if *profileName != "" {
+		config.SetName(profileName)
+	} else if len(availableProfiles) == 1 {
+		config.SetName(&availableProfiles[0])
 	}
 }
 

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -53,9 +53,6 @@ func (opts *SetOpts) Run() error {
 }
 
 func SetBuilder() *cobra.Command {
-	opts := &SetOpts{
-		store: config.Default(),
-	}
 	cmd := &cobra.Command{
 		Use:   "set <property> <value>",
 		Short: description.ConfigSetDescription,
@@ -71,8 +68,11 @@ func SetBuilder() *cobra.Command {
 		},
 		ValidArgs: config.Properties(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.prop = args[0]
-			opts.val = args[1]
+			opts := &SetOpts{
+				store: config.Default(),
+				prop:  args[0],
+				val:   args[1],
+			}
 			return opts.Run()
 		},
 	}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -303,7 +303,6 @@ func (p *profile) Load(readEnvironmentVars bool) error {
 		}
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -49,6 +49,7 @@ func Properties() []string {
 }
 
 var p = newProfile()
+var isDefaultProfileSet = false
 
 type Setter interface {
 	Set(string, string)
@@ -80,6 +81,16 @@ type Config interface {
 }
 
 func Default() Config {
+	if !isDefaultProfileSet {
+		profileNames := List()
+
+		// if only one profile is present, use that as the default
+		if len(profileNames) == 1 {
+			p.SetName(&profileNames[0])
+			isDefaultProfileSet = true
+		}
+	}
+
 	return p
 }
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -100,7 +100,7 @@ func newProfile() *profile {
 	if err != nil {
 		log.Fatal(err)
 	}
-	name := "default"
+	name := DefaultProfile
 	np := &profile{
 		name:      &name,
 		configDir: configDir,
@@ -304,17 +304,7 @@ func (p *profile) Load(readEnvironmentVars bool) error {
 		return err
 	}
 
-	p.setDefaultProfile()
-
 	return nil
-}
-
-// setDefaultProfile will figure out the name of the default profile to use after Loading.
-func (p *profile) setDefaultProfile() {
-	availableProfiles := List()
-	if len(availableProfiles) == 1 {
-		p.SetName(&availableProfiles[0])
-	}
 }
 
 // Save the configuration to disk

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -49,7 +49,6 @@ func Properties() []string {
 }
 
 var p = newProfile()
-var isDefaultProfileSet = false
 
 type Setter interface {
 	Set(string, string)
@@ -81,16 +80,6 @@ type Config interface {
 }
 
 func Default() Config {
-	if !isDefaultProfileSet {
-		profileNames := List()
-
-		// if only one profile is present, use that as the default
-		if len(profileNames) == 1 {
-			p.SetName(&profileNames[0])
-			isDefaultProfileSet = true
-		}
-	}
-
 	return p
 }
 
@@ -117,7 +106,6 @@ func newProfile() *profile {
 		configDir: configDir,
 		fs:        afero.NewOsFs(),
 	}
-	np.SetService(CloudService)
 	return np
 }
 
@@ -315,7 +303,18 @@ func (p *profile) Load(readEnvironmentVars bool) error {
 		}
 		return err
 	}
+
+	p.setDefaultProfile()
+
 	return nil
+}
+
+// setDefaultProfile will figure out the name of the default profile to use after Loading.
+func (p *profile) setDefaultProfile() {
+	availableProfiles := List()
+	if len(availableProfiles) == 1 {
+		p.SetName(&availableProfiles[0])
+	}
 }
 
 // Save the configuration to disk


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [Improve use of default profile to use any profile available](https://jira.mongodb.org/browse/CLOUDP-66132)


## Checklist

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

Only a default profile:

```
cat ~/.config/mongocli.toml

[default]
  base_url = "http://base_url.com/"
  ops_manager_skip_verify = "false"
  org_id = "5cac6a2179358edabd12b572"
  private_api_key = <>
  project_id = "5cac6a2ba6f239298a18a025"
  public_api_key = <>
  service = "cloud"
```

Gives:

` ./bin/mongocli atlas clusters list `

> Lists the clusters

```
./bin/mongocli atlas clusters list -P not_a_profile
Error: missing credentials 
```

Only one profile, not default:

```
cat ~/.config/mongocli.toml

[atlas]
  base_url = "http://base_url.com/"
  ops_manager_skip_verify = "false"
  org_id = "5cac6a2179358edabd12b572"
  private_api_key = <>
  project_id = "5cac6a2ba6f239298a18a025"
  public_api_key = <>
  service = "cloud"
```

Gives:

` ./bin/mongocli atlas clusters list `

> Lists the clusters

```
 ./bin/mongocli atlas clusters list -P not_a_profile
 Error: missing credentials
```

Two profiles, one default:

```
cat ~/.config/mongocli.toml

[default]
  base_url = "http://base_url.com/"
  ops_manager_skip_verify = "false"
  org_id = "5cac6a2179358edabd12b572"
  private_api_key = <>
  project_id = "5cac6a2ba6f239298a18a025"
  public_api_key = <>
  service = "cloud"

[atlas]
  base_url = "http://base_url.com/"
  ops_manager_skip_verify = "false"
  org_id = "5cac6a2179358edabd12b572"
  private_api_key = <>
  project_id = "5cac6a2ba6f239298a18a025"
  public_api_key = <>
  service = "cloud"
```

Gives:

` ./bin/mongocli atlas clusters list `

> Lists the clusters in default

```
 ./bin/mongocli atlas clusters list -P not_a_profile
 Error: missing credentials
```



