### PR TITLE
CLOUDP-66818: authenticate to barque using API key

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -326,7 +326,7 @@ functions:
           <<: *go_options
           NOTARY_KEY_NAME: ${notary_key_name|server-4.4}
           BARQUE_USERNAME: ${barque_user}
-          BARQUE_PASSWORD: ${barque_password}
+          BARQUE_API_KEY: ${barque_api_key}
         binary: build/package/curator-push.sh
 
 post:

--- a/build/package/curator-push.sh
+++ b/build/package/curator-push.sh
@@ -16,7 +16,7 @@
 
 export NOTARY_KEY_NAME
 export BARQUE_USERNAME
-export BARQUE_PASSWORD
+export BARQUE_API_KEY
 case "${NOTARY_KEY_NAME}" in
     server-4.2)
         export NOTARY_TOKEN=${signing_auth_token_42}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
The LDAP server is no longer supported so auth to barque should just use the service user's API key.

_Jira ticket:_ [CLOUDP-66818](https://jira.mongodb.org/browse/[CLOUDP-66818])

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have run `make fmt` and formatted my code

