### PR TITLE
CLOUDP-66899: mongocli atlas cluster(s) onlineArchive(s) start

### DIFF
--- a/internal/cli/atlas/onlinearchive/delete.go
+++ b/internal/cli/atlas/onlinearchive/delete.go
@@ -48,7 +48,7 @@ func DeleteBuilder() *cobra.Command {
 		DeleteOpts: cli.NewDeleteOpts("Archive '%s' deleted\n", "Archive not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:     "delete <id>",
+		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   description.DeleteOnlineArchive,
 		Args:    cobra.ExactArgs(1),

--- a/internal/cli/atlas/onlinearchive/delete_test.go
+++ b/internal/cli/atlas/onlinearchive/delete_test.go
@@ -42,8 +42,7 @@ func TestDelete_Run(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	err := deleteOpts.Run()
-	if err != nil {
+	if err := deleteOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }

--- a/internal/cli/atlas/onlinearchive/describe_test.go
+++ b/internal/cli/atlas/onlinearchive/describe_test.go
@@ -41,8 +41,7 @@ func TestDescribe_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	err := describeOpts.Run()
-	if err != nil {
+	if err := describeOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }

--- a/internal/cli/atlas/onlinearchive/list_test.go
+++ b/internal/cli/atlas/onlinearchive/list_test.go
@@ -40,8 +40,7 @@ func TestList_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	err := listOpts.Run()
-	if err != nil {
+	if err := listOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }

--- a/internal/cli/atlas/onlinearchive/online_archive.go
+++ b/internal/cli/atlas/onlinearchive/online_archive.go
@@ -29,6 +29,8 @@ func Builder() *cobra.Command {
 	cmd.AddCommand(ListBuilder())
 	cmd.AddCommand(DescribeBuilder())
 	cmd.AddCommand(CreateBuilder())
+	cmd.AddCommand(PauseBuilder())
+	cmd.AddCommand(StartBuilder())
 	cmd.AddCommand(DeleteBuilder())
 
 	return cmd

--- a/internal/cli/atlas/onlinearchive/pause.go
+++ b/internal/cli/atlas/onlinearchive/pause.go
@@ -46,7 +46,6 @@ func (opts *PauseOpts) Run() error {
 		Paused: &paused,
 	}
 	result, err := opts.store.UpdateOnlineArchive(opts.ConfigProjectID(), opts.clusterName, cluster)
-
 	if err != nil {
 		return err
 	}

--- a/internal/cli/atlas/onlinearchive/pause_test.go
+++ b/internal/cli/atlas/onlinearchive/pause_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onlinearchive
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/mocks"
+	"go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestPause_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockOnlineArchiveUpdater(ctrl)
+
+	defer ctrl.Finish()
+
+	updateOpts := &PauseOpts{
+		id:    "1",
+		store: mockStore,
+	}
+
+	paused := true
+	expected := &mongodbatlas.OnlineArchive{
+		ID:     updateOpts.id,
+		Paused: &paused,
+	}
+
+	mockStore.
+		EXPECT().
+		UpdateOnlineArchive(updateOpts.ConfigProjectID(), updateOpts.clusterName, expected).
+		Return(expected, nil).
+		Times(1)
+
+	err := updateOpts.Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/atlas/onlinearchive/start.go
+++ b/internal/cli/atlas/onlinearchive/start.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package onlinearchive
 
 import (
@@ -22,22 +23,29 @@ import (
 	"github.com/mongodb/mongocli/internal/store"
 	"github.com/mongodb/mongocli/internal/usage"
 	"github.com/spf13/cobra"
+	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-type ListOpts struct {
+type StartOpts struct {
 	cli.GlobalOpts
+	id          string
 	clusterName string
-	store       store.OnlineArchiveLister
+	store       store.OnlineArchiveUpdater
 }
 
-func (opts *ListOpts) initStore() error {
+func (opts *StartOpts) initStore() error {
 	var err error
 	opts.store, err = store.New(config.Default())
 	return err
 }
 
-func (opts *ListOpts) Run() error {
-	result, err := opts.store.OnlineArchives(opts.ConfigProjectID(), opts.clusterName)
+func (opts *StartOpts) Run() error {
+	paused := false
+	archive := &atlas.OnlineArchive{
+		ID:     opts.id,
+		Paused: &paused,
+	}
+	result, err := opts.store.UpdateOnlineArchive(opts.ConfigProjectID(), opts.clusterName, archive)
 
 	if err != nil {
 		return err
@@ -46,18 +54,18 @@ func (opts *ListOpts) Run() error {
 	return json.PrettyPrint(result)
 }
 
-// mongocli atlas onlineArchive(s) list [--projectId projectId] [--clusterName name]
-func ListBuilder() *cobra.Command {
-	opts := &ListOpts{}
+// mongocli atlas cluster(s) start <name> [--projectId projectId]
+func StartBuilder() *cobra.Command {
+	opts := &StartOpts{}
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   description.ListOnlineArchive,
-		Aliases: []string{"ls"},
-		Args:    cobra.NoArgs,
+		Use:   "start <id>",
+		Short: description.StartOnlineArchive,
+		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.initStore()
+			return opts.PreRunE(opts.initStore)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.id = args[0]
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/onlinearchive/start.go
+++ b/internal/cli/atlas/onlinearchive/start.go
@@ -58,7 +58,7 @@ func (opts *StartOpts) Run() error {
 func StartBuilder() *cobra.Command {
 	opts := &StartOpts{}
 	cmd := &cobra.Command{
-		Use:   "start <id>",
+		Use:   "start <ID>",
 		Short: description.StartOnlineArchive,
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/onlinearchive/start.go
+++ b/internal/cli/atlas/onlinearchive/start.go
@@ -46,7 +46,6 @@ func (opts *StartOpts) Run() error {
 		Paused: &paused,
 	}
 	result, err := opts.store.UpdateOnlineArchive(opts.ConfigProjectID(), opts.clusterName, archive)
-
 	if err != nil {
 		return err
 	}

--- a/internal/cli/atlas/onlinearchive/start_test.go
+++ b/internal/cli/atlas/onlinearchive/start_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onlinearchive
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/mocks"
+	"go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestStart_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockOnlineArchiveUpdater(ctrl)
+
+	defer ctrl.Finish()
+
+	updateOpts := &StartOpts{
+		id:    "1",
+		store: mockStore,
+	}
+
+	paused := false
+	expected := &mongodbatlas.OnlineArchive{
+		ID:     updateOpts.id,
+		Paused: &paused,
+	}
+
+	mockStore.
+		EXPECT().
+		UpdateOnlineArchive(updateOpts.ConfigProjectID(), updateOpts.clusterName, expected).
+		Return(expected, nil).
+		Times(1)
+
+	err := updateOpts.Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/description/description.go
+++ b/internal/description/description.go
@@ -86,6 +86,8 @@ const (
 	DescribeOnlineArchive    = "Describe an online archive for a cluster."
 	CreateOnlineArchive      = "Create an online archive for a cluster."
 	DeleteOnlineArchive      = "Delete an online archive from a cluster."
+	PauseOnlineArchive       = "Pause an online archive from a cluster."
+	StartOnlineArchive       = "Start a paused online archive from a cluster."
 	ConfigDescription        = "Configure a profile to store access settings for your MongoDB deployment."
 	ConfigSetDescription     = "Configure specific properties of a profile."
 	ConfigRenameDescription  = "Rename a profile."

--- a/internal/store/online_archives.go
+++ b/internal/store/online_archives.go
@@ -77,7 +77,7 @@ func (s *Store) CreateOnlineArchive(projectID, clusterName string, archive *atla
 	}
 }
 
-// CreateOnlineArchive encapsulate the logic to manage different cloud providers
+// UpdateOnlineArchive encapsulate the logic to manage different cloud providers
 func (s *Store) UpdateOnlineArchive(projectID, clusterName string, archive *atlas.OnlineArchive) (*atlas.OnlineArchive, error) {
 	switch s.service {
 	case config.CloudService:

--- a/internal/store/online_archives.go
+++ b/internal/store/online_archives.go
@@ -22,7 +22,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -destination=../mocks/mock_online_archives.go -package=mocks github.com/mongodb/mongocli/internal/store OnlineArchiveLister,OnlineArchiveDescriber,OnlineArchiveCreator,OnlineArchiveDeleter
+//go:generate mockgen -destination=../mocks/mock_online_archives.go -package=mocks github.com/mongodb/mongocli/internal/store OnlineArchiveLister,OnlineArchiveDescriber,OnlineArchiveCreator,OnlineArchiveUpdater,OnlineArchiveDeleter
 
 type OnlineArchiveLister interface {
 	OnlineArchives(string, string) ([]*atlas.OnlineArchive, error)
@@ -34,6 +34,10 @@ type OnlineArchiveDescriber interface {
 
 type OnlineArchiveCreator interface {
 	CreateOnlineArchive(string, string, *atlas.OnlineArchive) (*atlas.OnlineArchive, error)
+}
+
+type OnlineArchiveUpdater interface {
+	UpdateOnlineArchive(string, string, *atlas.OnlineArchive) (*atlas.OnlineArchive, error)
 }
 
 type OnlineArchiveDeleter interface {
@@ -67,6 +71,17 @@ func (s *Store) CreateOnlineArchive(projectID, clusterName string, archive *atla
 	switch s.service {
 	case config.CloudService:
 		result, _, err := s.client.(*atlas.Client).OnlineArchives.Create(context.Background(), projectID, clusterName, archive)
+		return result, err
+	default:
+		return nil, fmt.Errorf("unsupported service: %s", s.service)
+	}
+}
+
+// CreateOnlineArchive encapsulate the logic to manage different cloud providers
+func (s *Store) UpdateOnlineArchive(projectID, clusterName string, archive *atlas.OnlineArchive) (*atlas.OnlineArchive, error) {
+	switch s.service {
+	case config.CloudService:
+		result, _, err := s.client.(*atlas.Client).OnlineArchives.Update(context.Background(), projectID, clusterName, archive.ID, archive)
 		return result, err
 	default:
 		return nil, fmt.Errorf("unsupported service: %s", s.service)


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [Name of ticket](https://jira.mongodb.org/browse/[name-of-ticket])

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

pause 
```zsh
mongocli atlas clusters onlinearchive pause 5f08577acf7bf723975cb4c4 --clusterName testShard
{
	"_id": "5f08577acf7bf723975cb4c4",
	"clusterName": "testShard",
	"collName": "test",
	"criteria": {
		"dateField": "test",
		"expireAfterDays": 3
	},
	"dbName": "test",
	"groupId": "5e429f2e06822c6eac4d59c9",
	"partitionFields": [
		{
			"fieldName": "test",
			"fieldType": "date",
			"order": 0
		}
	],
	"paused": true,
	"state": "PAUSED"
}

```

start
```zsh
mongocli atlas clusters onlinearchive start 5f08577acf7bf723975cb4c4 --clusterName testShard
{
	"_id": "5f08577acf7bf723975cb4c4",
	"clusterName": "testShard",
	"collName": "test",
	"criteria": {
		"dateField": "test",
		"expireAfterDays": 3
	},
	"dbName": "test",
	"groupId": "5e429f2e06822c6eac4d59c9",
	"partitionFields": [
		{
			"fieldName": "test",
			"fieldType": "date",
			"order": 0
		}
	],
	"paused": false,
	"state": "ACTIVE"
}
```