### PR TITLE
CLOUDP-67058: Better test clean up

### DIFF
--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -29,6 +29,11 @@ func TestLogs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer func() {
+		if e := deleteCluster(clusterName); e != nil {
+			t.Errorf("error deleting test cluster: %v", e)
+		}
+	}()
 
 	hostname, err := getHostname()
 	if err != nil {
@@ -161,8 +166,4 @@ func TestLogs(t *testing.T) {
 			t.Fatalf("%v has not been downloaded", filepath)
 		}
 	})
-
-	if err := deleteCluster(clusterName); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 }

--- a/e2e/atlas/metrics_test.go
+++ b/e2e/atlas/metrics_test.go
@@ -31,6 +31,11 @@ func TestMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer func() {
+		if e := deleteCluster(clusterName); e != nil {
+			t.Errorf("error deleting test cluster: %v", e)
+		}
+	}()
 	hostname, err := getHostnameAndPort()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -154,7 +159,4 @@ func TestMetrics(t *testing.T) {
 			t.Errorf("got=%#v\nwant=%#v\n", 0, "len(metrics.Measurements) > 0")
 		}
 	})
-	if err := deleteCluster(clusterName); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-67058](https://jira.mongodb.org/browse/CLOUDP-67058)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

If some of our e2e would fail we would not always clean up the created clusters, this aims to be a more defensive way to make sure the delete function always runs on exit