### PR TITLE
CLOUDP-67961: update internal/cli/atlas/datalake to use the new output format

### DIFF
--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -38,6 +38,8 @@ func (opts *CreateOpts) initStore() error {
 	return err
 }
 
+var createTemplate = "Data lake '{{.Name}}' created.\n"
+
 func (opts *CreateOpts) Run() error {
 	createRequest := &mongodbatlas.DataLakeCreateRequest{
 		Name: opts.name,
@@ -48,7 +50,7 @@ func (opts *CreateOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), createTemplate, r)
 }
 
 // mongocli atlas datalake(s) create name --projectId projectId

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -37,13 +37,17 @@ func (opts *DescribeOpts) initStore() error {
 	return err
 }
 
+var describeTemplate = `Name	State
+{{.Name}}	{{.State}}
+`
+
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.DataLake(opts.ConfigProjectID(), opts.name)
 	if err != nil {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), describeTemplate, r)
 }
 
 // mongocli atlas datalake(s) describe name --projectId projectId

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -36,6 +36,10 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
+var listTemplate = `Name	State{{range.}}
+{{.Name}}	{{.State}}{{end}}
+`
+
 func (opts *ListOpts) Run() error {
 	r, err := opts.store.DataLakes(opts.ConfigProjectID())
 
@@ -43,7 +47,7 @@ func (opts *ListOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), listTemplate, r)
 }
 
 // mongocli atlas datalake(s) list --projectId projectId

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -67,6 +67,8 @@ func (opts *UpdateOpts) newUpdateRequest() *mongodbatlas.DataLakeUpdateRequest {
 	return updateRequest
 }
 
+var updateTemplate = "Data lake '{{.Name}}' updated.\n"
+
 func (opts *UpdateOpts) Run() error {
 	updateRequest := opts.newUpdateRequest()
 
@@ -75,7 +77,7 @@ func (opts *UpdateOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), updateTemplate, r)
 }
 
 // mongocli atlas datalake(s) update name --projectId projectId [--role role] [--testBucket bucket] [--region region]


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-67961

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

```zsh
$ mongocli atlas datalake create myDL -P dev
Data lake 'myDL' created.
```

```zsh
$ mongocli atlas datalake create myDL -P dev
Data lake 'myDL' created.
```

```zsh
$ mongocli atlas datalake describe myDL
Name	State
myDL	UNVERIFIED
```

```zsh
$ mongocli atlas datalake ls
Name	State
myLake	UNVERIFIED
myDL	UNVERIFIED
```