### PR TITLE
CLOUDP-67963: update internal/cli/atlas/onlinearchive to use the new output

### DIFF
--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -37,7 +37,7 @@ func (opts *DescribeOpts) initStore() error {
 	return err
 }
 
-var describeTemplate = `Name	State
+var describeTemplate = `NAME	STATE
 {{.Name}}	{{.State}}
 `
 

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -36,7 +36,7 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
-var listTemplate = `Name	State{{range.}}
+var listTemplate = `NAME	STATE{{range.}}
 {{.Name}}	{{.State}}{{end}}
 `
 

--- a/internal/cli/atlas/onlinearchive/create.go
+++ b/internal/cli/atlas/onlinearchive/create.go
@@ -46,6 +46,8 @@ func (opts *CreateOpts) initStore() error {
 	return err
 }
 
+var createTemplate = "Online archive '{{.ID}}' created.\n"
+
 func (opts *CreateOpts) Run() error {
 	archive, err := opts.newOnlineArchive()
 	if err != nil {
@@ -56,7 +58,7 @@ func (opts *CreateOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), createTemplate, r)
 }
 
 func (opts *CreateOpts) newOnlineArchive() (*atlas.OnlineArchive, error) {

--- a/internal/cli/atlas/onlinearchive/describe.go
+++ b/internal/cli/atlas/onlinearchive/describe.go
@@ -39,13 +39,17 @@ func (opts *DescribeOpts) initStore() error {
 	return err
 }
 
+var describeTemplate = `ID	CLUSTER	DATABASE	COLLECTION	STATE
+{{.ID}}	{{.ClusterName}} {{.DBName}}	{{.CollName}}	{{.State}}
+`
+
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.OnlineArchive(opts.ConfigProjectID(), opts.clusterName, opts.archiveID)
 	if err != nil {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), describeTemplate, r)
 }
 
 // mongocli atlas cluster(s) describe <name> [--clusterName name][--projectId projectId]

--- a/internal/cli/atlas/onlinearchive/describe.go
+++ b/internal/cli/atlas/onlinearchive/describe.go
@@ -40,7 +40,7 @@ func (opts *DescribeOpts) initStore() error {
 }
 
 var describeTemplate = `ID	CLUSTER	DATABASE	COLLECTION	STATE
-{{.ID}}	{{.ClusterName}} {{.DBName}}	{{.CollName}}	{{.State}}
+{{.ID}}	{{.ClusterName}}	{{.DBName}}	{{.CollName}}	{{.State}}
 `
 
 func (opts *DescribeOpts) Run() error {

--- a/internal/cli/atlas/onlinearchive/list.go
+++ b/internal/cli/atlas/onlinearchive/list.go
@@ -36,13 +36,17 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
+var listTemplate = `ID	DATABASE	COLLECTION	STATE{{range .}}
+{{.ID}}	{{.DBName}}	{{.CollName}}	{{.State}}{{end}}
+`
+
 func (opts *ListOpts) Run() error {
 	r, err := opts.store.OnlineArchives(opts.ConfigProjectID(), opts.clusterName)
 	if err != nil {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), listTemplate, r)
 }
 
 // mongocli atlas onlineArchive(s) list [--projectId projectId] [--clusterName name]

--- a/internal/cli/atlas/onlinearchive/pause.go
+++ b/internal/cli/atlas/onlinearchive/pause.go
@@ -39,6 +39,8 @@ func (opts *PauseOpts) initStore() error {
 	return err
 }
 
+var pauseTemplate = "Online archive '{{.ID}}' paused.\n"
+
 func (opts *PauseOpts) Run() error {
 	paused := true
 	cluster := &atlas.OnlineArchive{
@@ -50,7 +52,7 @@ func (opts *PauseOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), pauseTemplate, r)
 }
 
 // mongocli atlas cluster(s) onlineArchive(s) pause <ID> [--clusterName name][--projectId projectId]

--- a/internal/cli/atlas/onlinearchive/start.go
+++ b/internal/cli/atlas/onlinearchive/start.go
@@ -39,6 +39,8 @@ func (opts *StartOpts) initStore() error {
 	return err
 }
 
+var startTemplate = "Online archive '{{.ID}}' started.\n"
+
 func (opts *StartOpts) Run() error {
 	paused := false
 	archive := &atlas.OnlineArchive{
@@ -50,7 +52,7 @@ func (opts *StartOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), startTemplate, r)
 }
 
 // mongocli atlas cluster(s) onlineArchive(s) start <ID> [--clusterName name][--projectId projectId]

--- a/internal/cli/atlas/onlinearchive/update.go
+++ b/internal/cli/atlas/onlinearchive/update.go
@@ -40,6 +40,8 @@ func (opts *UpdateOpts) initStore() error {
 	return err
 }
 
+var updateTemplate = "Online archive '{{.ID}}' updated.\n"
+
 func (opts *UpdateOpts) Run() error {
 	archive := opts.newOnlineArchive()
 	r, err := opts.store.UpdateOnlineArchive(opts.ConfigProjectID(), opts.clusterName, archive)
@@ -47,7 +49,7 @@ func (opts *UpdateOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), updateTemplate, r)
 }
 
 func (opts *UpdateOpts) newOnlineArchive() *atlas.OnlineArchive {

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -39,7 +39,7 @@ func (opts *DescribeOpts) initStore() error {
 	return err
 }
 
-var describeTemplate = `ID	Name	Database	Collection
+var describeTemplate = `ID	NAME	DATABASE	COLLECTION
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}
 `
 

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -39,7 +39,7 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
-var listTemplate = `ID	Name	Database	Collection{{range .}}
+var listTemplate = `ID	NAME	DATABASE	COLLECTION{{range .}}
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}{{end}}
 `
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-67963

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

```zsh
$ mongocli atlas clusters onlinearchive create --db test --collection test --archiveAfter 3 --partition test:date --clusterName myDemo --dateField test
Online archive '5f205e4f4ace3c78da67dd2a' created.
```

```zsh
$ mongocli atlas clusters onlinearchive ls --clusterName myDemo 
ID				DATABASE	COLLECTION	STATE
5f205e4f4ace3c78da67dd2a	test		test		ACTIVE
```

```zsh
$ mongocli atlas clusters onlinearchive describe 5f205e4f4ace3c78da67dd2a --clusterName myDemo 
ID				CLUSTER		DATABASE	COLLECTION	STATE
5f205e4f4ace3c78da67dd2a	myDemo		test		test		ACTIVE
```