### PR TITLE
CLOUDP-68278: don't make generic cloud manager tests depend on spawn host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ UNIT_TAGS?=unit
 INTEGRATION_TAGS?=integration
 E2E_TAGS?=e2e
 E2E_BINARY?=../../bin/${BINARY_NAME}
+E2E_TIMEOUT?=20m
 
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
@@ -70,7 +71,7 @@ build: ## Generate a binary in ./bin
 e2e-test: build ## Run E2E tests
 	@echo "==> Running E2E tests..."
 	# the target assumes the MCLI-* environment variables are exported
-	${TEST_CMD} -v -p 1 -parallel 1 -timeout 15m -tags="${E2E_TAGS}" ./e2e...
+	${TEST_CMD} -v -p 1 -parallel 1 -timeout ${E2E_TIMEOUT} -tags="${E2E_TAGS}" ./e2e...
 
 .PHONY: integration-test
 integration-test: ## Run integration tests

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -537,9 +537,6 @@ tasks:
     commands:
       - func: "clone"
       - func: "install gotestsum"
-      - func: "deploy spawn host"
-      - func: ssh-ready
-      - func: "install automation agent"
       - func: "e2e test"
         vars:
           MCLI_ORG_ID: ${cloud_manager_org_id}
@@ -568,7 +565,7 @@ tasks:
           MCLI_PRIVATE_API_KEY: ${cloud_manager_private_api_key}
           MCLI_PUBLIC_API_KEY: ${cloud_manager_public_api_key}
           MCLI_SERVICE: cloud-manager
-          E2E_TAGS: cloudmanager,deploy_replica_set
+          E2E_TAGS: cloudmanager,remote
   - name: package_msi
     tags: ["packaging"]
     depends_on:
@@ -1148,8 +1145,8 @@ buildvariants:
       go_bin: "/opt/golang/go1.14/bin"
     tasks:
       - name: ".e2e .clusters .atlas"
-  - name: e2e_cloud_manager_clusters
-    display_name: "E2E Cloud Manager Cluster Tests"
+  - name: e2e_cloud_manager_remote
+    display_name: "E2E Cloud Manager Remote Host Tests"
     run_on:
       - rhel70-small
     expansions:

--- a/e2e/cloud_manager/dbusers_test.go
+++ b/e2e/cloud_manager/dbusers_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build e2e cloudmanager,generic
+// +build e2e cloudmanager,remote
 
 package cloud_manager_test
 

--- a/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/e2e/cloud_manager/deploy_replica_set_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build e2e cloudmanager,deploy_replica_set
+// +build e2e cloudmanager,remote
 
 package cloud_manager_test
 

--- a/e2e/cloud_manager/servers_test.go
+++ b/e2e/cloud_manager/servers_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build e2e cloudmanager,generic
+// +build e2e cloudmanager,remote
 
 package cloud_manager_test
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-68278

Closes #[issue number]

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Since we took some tests out of the PR suite we could speed it up a bit more if we don't make cloud manager generic depend on a spawn host