### PR TITLE
CLOUDP-68114: Add CAS field for security certs

### DIFF
--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -26,6 +26,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const createTemplate = `CAS
+{{.Cas}}
+`
+
 type SaveOpts struct {
 	cli.GlobalOpts
 	store   store.X509CertificateConfSaver
@@ -52,7 +56,7 @@ func (opts *SaveOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), createTemplate, r)
 }
 
 // mongocli atlas security customercerts create --projectId projectId --casFile /path/to/certificates.pem

--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -26,9 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const createTemplate = `CAS
-{{.Cas}}
-`
+const createTemplate = "Certificate successfully created.\n"
 
 type SaveOpts struct {
 	cli.GlobalOpts

--- a/internal/cli/atlas/security/customercerts/describe.go
+++ b/internal/cli/atlas/security/customercerts/describe.go
@@ -25,9 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const describeTemplate = `CAS
-{{.Cas}}
-`
+const describeTemplate = "{{.Cas}}\n"
 
 type DescribeOpts struct {
 	cli.GlobalOpts

--- a/internal/cli/atlas/security/customercerts/describe.go
+++ b/internal/cli/atlas/security/customercerts/describe.go
@@ -25,6 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const describeTemplate = `CAS
+{{.Cas}}
+`
+
 type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.ListOpts
@@ -43,7 +47,7 @@ func (opts *DescribeOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), describeTemplate, r)
 }
 
 // mongocli atlas security customerCerts describe --projectId projectId


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-68114

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added any necessary documentation (if appropriate)
- [] I have run `make fmt` and formatted my code

## Further comments

Just outputs the plain certificate:

```
./bin/mongocli atlas security customerCerts create --casFile ~/.ssh/bad_pem.pem
Certificate successfully created.
```

```
./bin/mongocli atlas security customerCerts describe
-----BEGIN CERTIFICATE-----
....
bSQR/NrJDA==
-----END CERTIFICATE-----

```
