### PR TITLE
CLOUDP-68273: update internal/cli/opsmanager/servers to use the simplified output

### DIFF
--- a/internal/cli/opsmanager/servers/list.go
+++ b/internal/cli/opsmanager/servers/list.go
@@ -39,13 +39,17 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
+var listTemplate = `HOSTNAME	STATE{{range .Results}}
+{{.Hostname}}	{{.StateName}}{{end}}
+`
+
 func (opts *ListOpts) Run() error {
 	r, err := opts.store.Agents(opts.ConfigProjectID(), agentType)
 	if err != nil {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), listTemplate, r)
 }
 
 // mongocli om server(s) list [--projectId projectId]


### PR DESCRIPTION
_Jira ticket:_ CLOUDP-68273

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

```zsh
$ mongocli om servers ls
HOSTNAME	STATE
host0		NO_PROCESSES
host1		NO_PROCESSES
host2		NO_PROCESSES
```