### PR TITLE
CLOUDP-68318: update cli/opsmanager/processes describe and list to use the simplified output

### DIFF
--- a/internal/cli/cloudmanager/cloud_manager.go
+++ b/internal/cli/cloudmanager/cloud_manager.go
@@ -17,7 +17,6 @@ package cloudmanager
 import (
 	"github.com/mongodb/mongocli/internal/cli/alerts"
 	"github.com/mongodb/mongocli/internal/cli/events"
-	"github.com/mongodb/mongocli/internal/cli/opsmanager"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/agents"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/automation"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/backup"
@@ -25,6 +24,7 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/dbusers"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/logs"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/metrics"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/processes"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/security"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/servers"
 	"github.com/mongodb/mongocli/internal/config"
@@ -52,7 +52,7 @@ func Builder() *cobra.Command {
 	cmd.AddCommand(security.Builder())
 	cmd.AddCommand(dbusers.Builder())
 	cmd.AddCommand(events.Builder())
-	cmd.AddCommand(opsmanager.ProcessesBuilder())
+	cmd.AddCommand(processes.Builder())
 	cmd.AddCommand(metrics.Builder())
 	cmd.AddCommand(logs.Builder())
 	cmd.AddCommand(agents.Builder())

--- a/internal/cli/opsmanager/ops_manager.go
+++ b/internal/cli/opsmanager/ops_manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/logs"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/metrics"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/owner"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/processes"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/security"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/servers"
 	"github.com/mongodb/mongocli/internal/config"
@@ -57,7 +58,7 @@ func Builder() *cobra.Command {
 	cmd.AddCommand(dbusers.Builder())
 	cmd.AddCommand(owner.Builder())
 	cmd.AddCommand(events.Builder())
-	cmd.AddCommand(ProcessesBuilder())
+	cmd.AddCommand(processes.Builder())
 	cmd.AddCommand(metrics.Builder())
 	cmd.AddCommand(logs.Builder())
 	cmd.AddCommand(agents.Builder())

--- a/internal/cli/opsmanager/processes/describe_test.go
+++ b/internal/cli/opsmanager/processes/describe_test.go
@@ -12,21 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package opsmanager
+// +build unit
+
+package processes
 
 import (
-	"github.com/mongodb/mongocli/internal/description"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/mocks"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
-func ProcessesBuilder() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "processes",
-		Aliases: []string{"process"},
-		Short:   description.Processes,
-	}
-	cmd.AddCommand(ProcessListBuilder())
-	cmd.AddCommand(ProcessDescribeBuilder())
+func TestDescribe_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockHostDescriber(ctrl)
+	defer ctrl.Finish()
 
-	return cmd
+	expected := &opsmngr.Host{}
+
+	opts := &DescribeOpts{
+		store: mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		Host(opts.ProjectID, opts.hostID).
+		Return(expected, nil).
+		Times(1)
+
+	err := opts.Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
 }

--- a/internal/cli/opsmanager/processes/list_test.go
+++ b/internal/cli/opsmanager/processes/list_test.go
@@ -14,7 +14,7 @@
 
 // +build unit
 
-package opsmanager
+package processes
 
 import (
 	"testing"
@@ -24,24 +24,24 @@ import (
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
-func TestProcessesDescribe_Run(t *testing.T) {
+func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockStore := mocks.NewMockHostDescriber(ctrl)
+	mockStore := mocks.NewMockHostLister(ctrl)
 	defer ctrl.Finish()
 
-	expected := &opsmngr.Host{}
+	expected := &opsmngr.Hosts{}
 
-	opts := &ProcessesDescribeOpts{
+	listOpts := &ListOpts{
 		store: mockStore,
 	}
 
 	mockStore.
 		EXPECT().
-		Host(opts.ProjectID, opts.hostID).
+		Hosts(listOpts.ProjectID, listOpts.newHostListOptions()).
 		Return(expected, nil).
 		Times(1)
 
-	err := opts.Run()
+	err := listOpts.Run()
 	if err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}

--- a/internal/cli/opsmanager/processes/processes.go
+++ b/internal/cli/opsmanager/processes/processes.go
@@ -12,37 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
-
-package opsmanager
+package processes
 
 import (
-	"testing"
-
-	"github.com/golang/mock/gomock"
-	"github.com/mongodb/mongocli/internal/mocks"
-	"go.mongodb.org/ops-manager/opsmngr"
+	"github.com/mongodb/mongocli/internal/description"
+	"github.com/spf13/cobra"
 )
 
-func TestProcessesList_Run(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockStore := mocks.NewMockHostLister(ctrl)
-	defer ctrl.Finish()
-
-	expected := &opsmngr.Hosts{}
-
-	listOpts := &ProcessesListOpts{
-		store: mockStore,
+func Builder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "processes",
+		Aliases: []string{"process"},
+		Short:   description.Processes,
 	}
+	cmd.AddCommand(ListBuilder())
+	cmd.AddCommand(DescribeBuilder())
 
-	mockStore.
-		EXPECT().
-		Hosts(listOpts.ProjectID, listOpts.newHostListOptions()).
-		Return(expected, nil).
-		Times(1)
-
-	err := listOpts.Run()
-	if err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
+	return cmd
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-68318

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->


```
./bin/mongocli om process list -P ops -o ""
ID					TYPE		HOSTNAME	PORT
2ab828e24a8ecb437f8c72a68a9b7c72	NO_DATA		andreaMac	29017
```

```
./bin/mongocli om process describe 2ab828e24a8ecb437f8c72a68a9b7c72 -P ops -o ""
ID					TYPE		HOSTNAME	PORT
2ab828e24a8ecb437f8c72a68a9b7c72	NO_DATA		andreaMac	29017
```
