### PR TITLE
CLOUDP-68272: update internal/cli/opsmanager/logs to use the simplified format

### DIFF
--- a/internal/cli/opsmanager/logs/jobs_collect.go
+++ b/internal/cli/opsmanager/logs/jobs_collect.go
@@ -46,12 +46,14 @@ func (opts *JobsCollectOpts) initStore() error {
 	return err
 }
 
+var collectTemplate = "Log collection job '{{.ID}}' started successfully.\n"
+
 func (opts *JobsCollectOpts) Run() error {
 	r, err := opts.store.Collect(opts.ConfigProjectID(), opts.newLog())
 	if err != nil {
 		return err
 	}
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), collectTemplate, r)
 }
 
 func (opts *JobsCollectOpts) newLog() *opsmngr.LogCollectionJob {

--- a/internal/cli/opsmanager/logs/jobs_list.go
+++ b/internal/cli/opsmanager/logs/jobs_list.go
@@ -38,12 +38,16 @@ func (opts *JobsListOpts) initStore() error {
 	return err
 }
 
+var listTemplate = `ID	CREATED AT	EXPIRES AT	STATUS	URL	REDACTED{{range .Results}}
+{{.ID}}	{{.CreationDate}}	{{.ExpirationDate}}	{{.Status}}	{{.URL}}	{{.Redacted}}{{end}}
+`
+
 func (opts *JobsListOpts) Run() error {
 	r, err := opts.store.LogCollectionJobs(opts.ConfigProjectID(), opts.newLogListOptions())
 	if err != nil {
 		return err
 	}
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), listTemplate, r)
 }
 
 func (opts *JobsListOpts) newLogListOptions() *opsmngr.LogListOptions {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-68272

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

```zsh
$ mongocli ops-manager logs jobs collect REPLICASET myReplicaSet --sizeRequestedPerFileBytes 10000000 --type MONGODB
Log collection job '5f21966596379e49248ca87f' started successfully.
```

```zsh
$ mongocli om log jobs ls
ID				CREATED AT		EXPIRES AT		STATUS		URL															REDACTED
5f21966596379e49248ca87f	2020-07-29T15:31:49Z	2020-08-28T15:31:49Z	SUCCESS		http://mms:8080/api/public/v1.0/groups/5f219152a4380e6bd8539b2c/logCollectionJobs/5f21966596379e49248ca87f/download	false
```
