### PR TITLE
CLOUDP-68337: internal/cli/atlas/metrics and internal/cli/opsmanager/metrics to use the simplified output

### DIFF
--- a/internal/cli/opsmanager/metrics/databases_list.go
+++ b/internal/cli/opsmanager/metrics/databases_list.go
@@ -38,6 +38,10 @@ func (opts *DatabasesListsOpts) initStore() error {
 	return err
 }
 
+var DatabasesListTemplate = `NAME{{range .Results}}
+{{.DatabaseName}}{{end}}
+`
+
 func (opts *DatabasesListsOpts) Run() error {
 	listOpts := opts.NewListOptions()
 	r, err := opts.store.HostDatabases(opts.ConfigProjectID(), opts.hostID, listOpts)
@@ -46,10 +50,10 @@ func (opts *DatabasesListsOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), DatabasesListTemplate, r)
 }
 
-// mongocli om metric(s) process(es) disks lists <ID>
+// mongocli om metric(s) process(es) disks lists <HOST_ID>
 func DatabasesListBuilder() *cobra.Command {
 	opts := &DatabasesListsOpts{}
 	cmd := &cobra.Command{

--- a/internal/cli/opsmanager/metrics/databases_list.go
+++ b/internal/cli/opsmanager/metrics/databases_list.go
@@ -38,7 +38,7 @@ func (opts *DatabasesListsOpts) initStore() error {
 	return err
 }
 
-var DatabasesListTemplate = `NAME{{range .Results}}
+var databasesListTemplate = `{{range .Results}}
 {{.DatabaseName}}{{end}}
 `
 
@@ -50,7 +50,7 @@ func (opts *DatabasesListsOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), DatabasesListTemplate, r)
+	return output.Print(config.Default(), databasesListTemplate, r)
 }
 
 // mongocli om metric(s) process(es) disks lists <HOST_ID>

--- a/internal/cli/opsmanager/metrics/disks_describe.go
+++ b/internal/cli/opsmanager/metrics/disks_describe.go
@@ -39,9 +39,9 @@ func (opts *DisksDescribeOpts) initStore() error {
 	return err
 }
 
-var diskMetricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .ProcessMeasurements.Measurements}}
-{{.Name}}	{{.Units}}{{range .DataPoints}}	
-		{{.Timestamp}}	{{.Value}}{{end}}{{end}}
+var diskMetricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .ProcessMeasurements.Measurements}}  {{if .DataPoints}}
+{{ $name := .Name }}	{{ $unit := .Units }}{{range .DataPoints}}	
+{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}{{ .Value }}{{else}} N/A {{end}}{{end}}{{end}}{{end}}
 `
 
 func (opts *DisksDescribeOpts) Run() error {

--- a/internal/cli/opsmanager/metrics/disks_describe.go
+++ b/internal/cli/opsmanager/metrics/disks_describe.go
@@ -40,8 +40,8 @@ func (opts *DisksDescribeOpts) initStore() error {
 }
 
 var diskMetricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .ProcessMeasurements.Measurements}}  {{if .DataPoints}}
-{{ $name := .Name }}	{{ $unit := .Units }}{{range .DataPoints}}	
-{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}{{ .Value }}{{else}} N/A {{end}}{{end}}{{end}}{{end}}
+{{- $name := .Name }}{{- $unit := .Units }}{{- range .DataPoints}}	
+{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}	{{ .Value }}{{else}}	N/A {{end}}{{end}}{{end}}{{end}}
 `
 
 func (opts *DisksDescribeOpts) Run() error {

--- a/internal/cli/opsmanager/metrics/disks_describe.go
+++ b/internal/cli/opsmanager/metrics/disks_describe.go
@@ -39,6 +39,11 @@ func (opts *DisksDescribeOpts) initStore() error {
 	return err
 }
 
+var diskMetricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .ProcessMeasurements.Measurements}}
+{{.Name}}	{{.Units}}{{range .DataPoints}}	
+		{{.Timestamp}}	{{.Value}}{{end}}{{end}}
+`
+
 func (opts *DisksDescribeOpts) Run() error {
 	listOpts := opts.NewProcessMetricsListOptions()
 	r, err := opts.store.HostDiskMeasurements(opts.ConfigProjectID(), opts.hostID, opts.name, listOpts)
@@ -46,7 +51,7 @@ func (opts *DisksDescribeOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), diskMetricTemplate, r)
 }
 
 // mcli om metric(s) disk(s) describe <hostId:port> <name> --granularity g --period p --start start --end end [--type type] [--projectId projectId]

--- a/internal/cli/opsmanager/metrics/disks_describe_test.go
+++ b/internal/cli/opsmanager/metrics/disks_describe_test.go
@@ -29,7 +29,11 @@ func TestDisksDescribeOpts_Run(t *testing.T) {
 	mockStore := mocks.NewMockHostDiskMeasurementsLister(ctrl)
 	defer ctrl.Finish()
 
-	expected := &mongodbatlas.ProcessDiskMeasurements{}
+	expected := &mongodbatlas.ProcessDiskMeasurements{
+		ProcessMeasurements: &mongodbatlas.ProcessMeasurements{
+			Measurements: []*mongodbatlas.Measurements{},
+		},
+	}
 
 	listOpts := &DisksDescribeOpts{
 		hostID: "1",

--- a/internal/cli/opsmanager/metrics/disks_list.go
+++ b/internal/cli/opsmanager/metrics/disks_list.go
@@ -38,7 +38,7 @@ func (opts *DisksListsOpts) initStore() error {
 	return err
 }
 
-var listTemplate = `NAME{{range .Results}}
+var listTemplate = `{{range .Results}}
 {{.PartitionName}}{{end}}
 `
 

--- a/internal/cli/opsmanager/metrics/disks_list.go
+++ b/internal/cli/opsmanager/metrics/disks_list.go
@@ -38,6 +38,10 @@ func (opts *DisksListsOpts) initStore() error {
 	return err
 }
 
+var listTemplate = `NAME{{range .Results}}
+{{.PartitionName}}{{end}}
+`
+
 func (opts *DisksListsOpts) Run() error {
 	listOpts := opts.NewListOptions()
 	r, err := opts.store.HostDisks(opts.ConfigProjectID(), opts.hostID, listOpts)
@@ -45,7 +49,7 @@ func (opts *DisksListsOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), listTemplate, r)
 }
 
 // mongocli om metric(s) process(es) disks lists <ID>

--- a/internal/cli/opsmanager/metrics/process.go
+++ b/internal/cli/opsmanager/metrics/process.go
@@ -38,9 +38,9 @@ func (opts *ProcessOpts) initStore() error {
 	return err
 }
 
-var metricTemplate = `NAME	UNITS			TIMESTAMP		VALUE{{range .Measurements}}
-{{.Name}}	{{.Units}}{{range .DataPoints}}	
-			{{.Timestamp}}	{{.Value}}{{end}}{{end}}
+var metricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .Measurements}} {{if .DataPoints}}
+{{ $name := .Name }}	{{ $unit := .Units }} {{range .DataPoints}}	
+{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}{{ .Value }}{{else}} N/A {{end}}{{end}}{{end}}{{end}}
 `
 
 func (opts *ProcessOpts) Run() error {

--- a/internal/cli/opsmanager/metrics/process.go
+++ b/internal/cli/opsmanager/metrics/process.go
@@ -38,6 +38,11 @@ func (opts *ProcessOpts) initStore() error {
 	return err
 }
 
+var metricTemplate = `NAME	UNITS			TIMESTAMP		VALUE{{range .Measurements}}
+{{.Name}}	{{.Units}}{{range .DataPoints}}	
+			{{.Timestamp}}	{{.Value}}{{end}}{{end}}
+`
+
 func (opts *ProcessOpts) Run() error {
 	listOpts := opts.NewProcessMetricsListOptions()
 	r, err := opts.store.HostMeasurements(opts.ConfigProjectID(), opts.hostID, listOpts)
@@ -45,7 +50,7 @@ func (opts *ProcessOpts) Run() error {
 		return err
 	}
 
-	return output.Print(config.Default(), "", r)
+	return output.Print(config.Default(), metricTemplate, r)
 }
 
 // mongocli om|cm metric(s) process(es) <ID> [--granularity granularity] [--period period] [--start start] [--end end] [--type type][--projectId projectId]

--- a/internal/cli/opsmanager/metrics/process.go
+++ b/internal/cli/opsmanager/metrics/process.go
@@ -39,8 +39,8 @@ func (opts *ProcessOpts) initStore() error {
 }
 
 var metricTemplate = `NAME	UNITS	TIMESTAMP		VALUE{{range .Measurements}} {{if .DataPoints}}
-{{ $name := .Name }}	{{ $unit := .Units }} {{range .DataPoints}}	
-{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}{{ .Value }}{{else}} N/A {{end}}{{end}}{{end}}{{end}}
+{{- $name := .Name }}{{- $unit := .Units }}{{- range .DataPoints}}	
+{{ $name }}	{{ $unit }}	{{.Timestamp}}	{{if .Value }}	{{ .Value }}{{else}}	N/A {{end}}{{end}}{{end}}{{end}}
 `
 
 func (opts *ProcessOpts) Run() error {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-68337

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->

Closes #[issue number]

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->



```
./bin/mongocli om metric processes ad00123ce121da3bdc7784fdaa5dbf0b --granularity PT30M --period P1DT12H -P ops -o ""
NAME					UNITS		TIMESTAMP			VALUE
PROCESS_CPU_USER			PERCENT		2020-07-29T16:33:23Z		0.5280867
PROCESS_CPU_USER			PERCENT		2020-07-29T17:03:23Z		0.5393118
PROCESS_CPU_USER			PERCENT		2020-07-29T17:33:23Z		0.541945
PROCESS_CPU_USER			PERCENT		2020-07-29T18:33:23Z		0.0053553963
PROCESS_CPU_USER			PERCENT		2020-07-29T19:03:23Z		0.40095562
PROCESS_CPU_USER			PERCENT		2020-07-29T20:03:23Z		0.0018521702
PROCESS_CPU_USER			PERCENT		2020-07-29T21:03:23Z		0.00400066
PROCESS_CPU_USER			PERCENT		2020-07-29T21:33:23Z		0.5555369
PROCESS_CPU_USER			PERCENT		2020-07-29T22:03:23Z		0.2864721
PROCESS_CPU_USER			PERCENT		2020-07-30T05:33:23Z		0.21684264
PROCESS_CPU_USER			PERCENT		2020-07-30T06:03:23Z		0.005284037
PROCESS_CPU_USER			PERCENT		2020-07-30T07:33:23Z		0.512581
PROCESS_CPU_USER			PERCENT		2020-07-30T08:03:23Z		0.54988873
PROCESS_CPU_USER			PERCENT		2020-07-30T08:33:23Z		0.5720924
PROCESS_CPU_USER			PERCENT		2020-07-30T09:03:23Z		0.5537544
PROCESS_CPU_USER			PERCENT		2020-07-30T09:33:23Z		0.55516636
PROCESS_CPU_USER			PERCENT		2020-07-30T10:03:23Z		0.544323
PROCESS_CPU_USER			PERCENT		2020-07-30T10:33:23Z		0.54767776
PROCESS_CPU_USER			PERCENT		2020-07-30T11:03:23Z		0.542094
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T16:33:23Z		0.24537982
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T17:03:23Z		0.2577142
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T17:33:23Z		0.26936373
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T18:33:23Z		0.0029211252
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T19:03:23Z		0.20047781
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T20:03:23Z		0.0009260851
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T21:03:23Z		0.0018464584
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T21:33:23Z		0.30558184
PROCESS_CPU_KERNEL			PERCENT		2020-07-29T22:03:23Z		0.15862548
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T05:33:23Z		0.10851378
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T06:03:23Z		0.006605046
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T07:33:23Z		0.24691841
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T08:03:23Z		0.26339957
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T08:33:23Z		0.28160265
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T09:03:23Z		0.27271134
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T09:33:23Z		0.2777981
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T10:03:23Z		0.26605174
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T10:33:23Z		0.26828426
PROCESS_CPU_KERNEL			PERCENT		2020-07-30T11:03:23Z		0.26327088
PROCESS_CPU_CHILDREN_USER		PERCENT		2020-07-29T16:33:23Z		N/A
PROCESS_CPU_CHILDREN_USER		PERCENT		2020-07-29T17:03:23Z		N/A
PROCESS_CPU_CHILDREN_USER		PERCENT		2020-07-29T17:33:23Z		N/A
```

```
./bin/mongocli om metric disk list  ad00123ce121da3bdc7784fdaa5dbf0b -P ops -o ""
test
```

```
./bin/mongocli om metric database list  ad00123ce121da3bdc7784fdaa5dbf0b -P ops -o ""
local
```

```
/bin/mongocli om metric disk describe ad00123ce121da3bdc7784fdaa5dbf0b test --granularity PT30M --period P1DT12H -P ops -o ""
NAME					UNITS			TIMESTAMP			VALUE
DISK_PARTITION_IOPS_READ		SCALAR_PER_SECOND	2020-07-29T16:34:23Z		N/A
DISK_PARTITION_IOPS_READ		SCALAR_PER_SECOND	2020-07-29T17:04:23Z		N/A
DISK_PARTITION_IOPS_READ		SCALAR_PER_SECOND	2020-07-29T17:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-29T20:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-29T21:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-29T21:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-29T22:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T05:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T06:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T07:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T08:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T08:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T09:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T09:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T10:04:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T10:34:23Z		N/A
DISK_PARTITION_IOPS_WRITE		SCALAR_PER_SECOND	2020-07-30T11:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T16:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T17:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T17:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T18:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T19:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T20:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T21:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T21:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-29T22:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T05:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T06:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T07:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T08:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T08:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T09:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T09:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T10:04:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T10:34:23Z		N/A
DISK_PARTITION_IOPS_TOTAL		SCALAR_PER_SECOND	2020-07-30T11:04:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T16:34:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T17:04:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T17:34:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T18:34:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T19:04:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T20:04:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T21:04:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T21:34:23Z		N/A
DISK_PARTITION_UTILIZATION		PERCENT			2020-07-29T22:04:23Z		N/A

```