### PR TITLE
CLOUDP-70467: Default networking peering list to AWS to match the API

### DIFF
--- a/internal/cli/atlas/networking/peering/list.go
+++ b/internal/cli/atlas/networking/peering/list.go
@@ -77,7 +77,7 @@ func ListBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.provider, flag.Provider, "", usage.Provider)
+	cmd.Flags().StringVar(&opts.provider, flag.Provider, "AWS", usage.Provider)
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, 0, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, 0, usage.Limit)
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-70467


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This is the default behaviour of the API, there's not way to get them all, so I'm making this change so it's explicit for users running the command help