### PR TITLE
CLOUDP-70550: Allow comma separate values for roles

### DIFF
--- a/internal/cli/atlas/clusters/indexes_create.go
+++ b/internal/cli/atlas/clusters/indexes_create.go
@@ -117,7 +117,7 @@ func IndexesCreateBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
 	cmd.Flags().StringVar(&opts.db, flag.Database, "", usage.Database)
 	cmd.Flags().StringVar(&opts.collection, flag.Collection, "", usage.Collection)
-	cmd.Flags().StringArrayVar(&opts.keys, flag.Key, nil, usage.Key)
+	cmd.Flags().StringSliceVar(&opts.keys, flag.Key, []string{}, usage.Key)
 	cmd.Flags().BoolVar(&opts.unique, flag.Unique, false, usage.Unique)
 	cmd.Flags().BoolVar(&opts.sparse, flag.Sparse, false, usage.Sparse)
 	cmd.Flags().BoolVar(&opts.background, flag.Background, false, usage.Background)

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -75,7 +75,7 @@ func CreateBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&opts.roles, flag.Role, nil, usage.APIKeyRoles)
+	cmd.Flags().StringSliceVar(&opts.roles, flag.Role, []string{}, usage.APIKeyRoles)
 	cmd.Flags().StringVar(&opts.description, flag.Description, "", usage.APIKeyDescription)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -165,7 +165,7 @@ func IndexesCreateBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.db, flag.Database, "", usage.Database)
 	cmd.Flags().StringVar(&opts.rsName, flag.RSName, "", usage.RSName)
 	cmd.Flags().StringVar(&opts.collection, flag.CollectionName, "", usage.Collection)
-	cmd.Flags().StringArrayVar(&opts.keys, flag.Key, nil, usage.Key)
+	cmd.Flags().StringSliceVar(&opts.keys, flag.Key, []string{}, usage.Key)
 	cmd.Flags().StringVar(&opts.locale, flag.Locale, "", usage.Locale)
 	cmd.Flags().StringVar(&opts.caseFirst, flag.CaseFirst, "", usage.CaseFirst)
 	cmd.Flags().StringVar(&opts.alternate, flag.Alternate, "", usage.Alternate)

--- a/internal/cli/opsmanager/logs/jobs_collect.go
+++ b/internal/cli/opsmanager/logs/jobs_collect.go
@@ -97,7 +97,7 @@ func JobsCollectOptsBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&opts.logTypes, flag.Type, nil, usage.LogTypes)
+	cmd.Flags().StringSliceVar(&opts.logTypes, flag.Type, []string{}, usage.LogTypes)
 	cmd.Flags().Int64Var(&opts.sizeRequestedPerFileBytes, flag.SizeRequestedPerFileBytes, 0, usage.SizeRequestedPerFileBytes)
 	cmd.Flags().BoolVar(&opts.redacted, flag.Redacted, false, usage.LogRedacted)
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-70550

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

`StringArrayVar` doesn't handle `--role ROLE_1,ROLE2` only `--role ROLE_1 --role ROLE_2` while `StringSliceVar` does
