### PR TITLE
CLOUDP-70719: wrong output for create dbuser cert

### DIFF
--- a/internal/cli/atlas/dbusers/certs/create.go
+++ b/internal/cli/atlas/dbusers/certs/create.go
@@ -46,7 +46,7 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-var createTemplate = "Certificate created '{{.ID}}'\n"
+var createTemplate = "{{.Certificate}}\n"
 
 // mongocli atlas dbuser(s) certs create --username <username> [--monthsUntilExpiration number] [--projectId projectId]
 func CreateBuilder() *cobra.Command {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-70719

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

```zsh
$ mongocli atlas dbusers certs create --username test1 -P dev
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
-----BEGIN PRIVATE KEY-----
...
-----END PRIVATE KEY-----
```
