### PR TITLE
CLOUDP-71439: Investigate why atlas integration(s) create|update VICTOR_OPS does not list VICTOR_OPS

### DIFF
--- a/e2e/atlas/integrations_test.go
+++ b/e2e/atlas/integrations_test.go
@@ -196,6 +196,8 @@ func TestIntegrations(t *testing.T) {
 			victorOpsEntity,
 			"--apiKey",
 			key,
+			"--routingKey",
+			"test",
 			"--projectId",
 			projectID,
 			"-o=json")
@@ -204,6 +206,11 @@ func TestIntegrations(t *testing.T) {
 
 		a := assert.New(t)
 		a.NoError(err, string(resp))
+
+		var thirdPartyIntegrations mongodbatlas.ThirdPartyIntegrations
+		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
+			a.True(integrationExists(victorOpsEntity, thirdPartyIntegrations))
+		}
 	})
 
 	t.Run("Create WEBHOOK", func(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/victor_ops.go
+++ b/internal/cli/atlas/integrations/create/victor_ops.go
@@ -84,6 +84,7 @@ func VictorOpsBuilder() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	_ = cmd.MarkFlagRequired(flag.APIKey)
+	_ = cmd.MarkFlagRequired(flag.RoutingKey)
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-71439

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->


The issue seems to occur only when we do not set the flag --routingKey . This property is optional according to documentation and the atlas UI so this is a problem of the endpoint. I am going to create a ticket for core/iam to verify this behaviour.
In the meantime, I am going to set --routingKey as required.


```
./bin/mongocli atlas integrations create VICTOR_OPS --apiKey 2eb02ae8-a198-431c-aa8a-XXXXXXX -o json --routingKey test
{
  "links": [
    {
      "rel": "self",
      "href": "https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/5e4e593f70dfbf1010295836/integrations/VICTOR_OPS?pageNum=1\u0026itemsPerPage=100"
    }
  ],
  "results": [
    {
      "type": "PAGER_DUTY",
      "serviceKey": "51c0ef87e9951c3e147accf0e1270"
    },
    {
      "type": "VICTOR_OPS",
      "apiKey": "2eb02ae8-a198-431c-aa8a-XXXXXXXX",
      "routingKey": "test"
    }
  ],
  "totalCount": 2
}
```
