### PR TITLE
CLOUDP-72054: Investigate why we are getting an error when we do not set --secret to configure webhook

### DIFF
--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -84,6 +84,7 @@ func WebhookBuilder() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	_ = cmd.MarkFlagRequired(flag.URL)
+	_ = cmd.MarkFlagRequired(flag.Secret)
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-72054

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->
This property is optional according to documentation and the atlas UI so this is a problem of the endpoint. I am going to create a ticket for core/iam to verify this behaviour.
In the meantime, I am going to set --secret as required.