### PR TITLE
CLOUDP-73125: mongocli atlas networking peering watch doe snot work for AWS

### DIFF
--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -82,5 +82,6 @@ func WatchBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	return cmd
 }

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -36,12 +36,22 @@ func (opts *WatchOpts) initStore() error {
 	return err
 }
 
+const (
+	waitingForUser    = "WAITING_FOR_USER"
+	failed            = "FAILED"
+	available         = "AVAILABLE"
+	pendingAcceptance = "PENDING_ACCEPTANCE"
+)
+
 func (opts *WatchOpts) watcher() (bool, error) {
 	result, err := opts.store.PeeringConnection(opts.ConfigProjectID(), opts.id)
 	if err != nil {
 		return false, err
 	}
-	return result.Status == "WAITING_FOR_USER" || result.Status == "FAILED" || result.Status == "AVAILABLE", nil
+	if result.Status != "" {
+		return result.Status == waitingForUser || result.Status == failed || result.Status == available, nil
+	}
+	return result.StatusName == pendingAcceptance || result.StatusName == failed || result.StatusName == available, nil
 }
 
 func (opts *WatchOpts) Run() error {

--- a/internal/cli/atlas/networking/peering/watch_test.go
+++ b/internal/cli/atlas/networking/peering/watch_test.go
@@ -20,30 +20,54 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/flag"
 	"github.com/mongodb/mongocli/internal/mocks"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
-func TestWatch_Run(t *testing.T) {
+func TestWatchBuilder(t *testing.T) {
+	cli.CmdValidator(t, WatchBuilder(), 0, []string{flag.ProjectID, flag.Output})
+}
+
+func TestWatchOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPeeringConnectionDescriber(ctrl)
 	defer ctrl.Finish()
 
-	describeOpts := &WatchOpts{
-		id:    "test",
-		store: mockStore,
+	tests := []struct {
+		name     string
+		expected *mongodbatlas.Peer
+	}{
+		{
+			name:     "AWS",
+			expected: &mongodbatlas.Peer{StatusName: "PENDING_ACCEPTANCE"},
+		},
+		{
+			name:     "AZURE",
+			expected: &mongodbatlas.Peer{Status: "AVAILABLE"},
+		},
+		{
+			name:     "GCP",
+			expected: &mongodbatlas.Peer{Status: "WAITING_FOR_USER"},
+		},
 	}
+	for _, tt := range tests {
+		expected := tt.expected
+		t.Run(tt.name, func(t *testing.T) {
+			describeOpts := &WatchOpts{
+				id:    "test",
+				store: mockStore,
+			}
+			mockStore.
+				EXPECT().
+				PeeringConnection(describeOpts.ProjectID, describeOpts.id).
+				Return(expected, nil).
+				Times(1)
 
-	expected := &mongodbatlas.Peer{Status: "WAITING_FOR_USER"}
-
-	mockStore.
-		EXPECT().
-		PeeringConnection(describeOpts.ProjectID, describeOpts.id).
-		Return(expected, nil).
-		Times(1)
-
-	err := describeOpts.Run()
-	if err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
+			if err := describeOpts.Run(); err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-73125

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

AWS uses a different field to report status
