### PR TITLE
CLOUDP-73287: allow to enable monitoring or backup agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tangzero/inflector v1.0.0
 	go.mongodb.org/atlas v0.4.1-0.20200916093941-a86355b45816
-	go.mongodb.org/ops-manager v0.9.4-0.20200916103147-819db682dbc7
+	go.mongodb.org/ops-manager v0.9.4-0.20200918132531-11085c971c80
 	golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a // indirect
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/atlas v0.4.1-0.20200916093941-a86355b45816 h1:wnYPHWDNpG0XaMebz6LBe7RRb6c+2bzmZ7bcDJDbWcg=
 go.mongodb.org/atlas v0.4.1-0.20200916093941-a86355b45816/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
-go.mongodb.org/ops-manager v0.9.4-0.20200916103147-819db682dbc7 h1:4DYsu+YoFql0caWOPXcElHvSJjDDPIZ0MdzFzvDxBTQ=
-go.mongodb.org/ops-manager v0.9.4-0.20200916103147-819db682dbc7/go.mod h1:r7sU/JNPvYANcUxECB+zox4XR+vbrh//o6ejPWLfjCc=
+go.mongodb.org/ops-manager v0.9.4-0.20200918132531-11085c971c80 h1:P5XBWK4HoDHIkTxE+lN8lzVt1JxbS7Fg/S3bA8Wutyk=
+go.mongodb.org/ops-manager v0.9.4-0.20200918132531-11085c971c80/go.mod h1:r7sU/JNPvYANcUxECB+zox4XR+vbrh//o6ejPWLfjCc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/cli/cloudmanager/cloud_manager.go
+++ b/internal/cli/cloudmanager/cloud_manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/logs"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/maintenance"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/metrics"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/monitoring"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/processes"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/security"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/servers"
@@ -56,6 +57,7 @@ func Builder() *cobra.Command {
 		security.Builder(),
 		dbusers.Builder(),
 		events.Builder(),
+		monitoring.Builder(),
 		processes.Builder(),
 		metrics.Builder(),
 		logs.Builder(),

--- a/internal/cli/cloudmanager/cloud_manager_test.go
+++ b/internal/cli/cloudmanager/cloud_manager_test.go
@@ -1,0 +1,16 @@
+package cloudmanager
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongocli/internal/cli"
+)
+
+func TestBuilder(t *testing.T) {
+	cli.CmdValidator(
+		t,
+		Builder(),
+		15,
+		[]string{},
+	)
+}

--- a/internal/cli/opsmanager/automation/describe.go
+++ b/internal/cli/opsmanager/automation/describe.go
@@ -54,7 +54,10 @@ func DescribeBuilder() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Hidden:  true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.PreRunE(opts.initStore)
+			return opts.PreRunE(
+				opts.initStore,
+				opts.InitOutput(cmd.OutOrStdout(), "use json output"),
+			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/internal/cli/opsmanager/backup/backup.go
+++ b/internal/cli/opsmanager/backup/backup.go
@@ -27,9 +27,12 @@ func Builder() *cobra.Command {
 		Short:   Backup,
 	}
 
-	cmd.AddCommand(SnapshotsBuilder())
-	cmd.AddCommand(RestoresBuilder())
-	cmd.AddCommand(CheckpointsBuilder())
+	cmd.AddCommand(
+		SnapshotsBuilder(),
+		RestoresBuilder(),
+		CheckpointsBuilder(),
+		EnableBuilder(),
+	)
 
 	return cmd
 }

--- a/internal/cli/opsmanager/backup/enable.go
+++ b/internal/cli/opsmanager/backup/enable.go
@@ -43,12 +43,12 @@ func (opts *EnableOpts) Run() error {
 	return nil
 }
 
-// mongocli ops-manager monitoring enable  [--projectId projectId]
+// mongocli ops-manager monitoring enable <hostname> [--projectId projectId]
 func EnableBuilder() *cobra.Command {
 	opts := &EnableOpts{}
 	cmd := &cobra.Command{
-		Use:   "enable",
-		Short: "Enable monitoring for a given host",
+		Use:   "enable <hostname>",
+		Short: "Enable backup for a given hostname",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/backup/enable.go
+++ b/internal/cli/opsmanager/backup/enable.go
@@ -1,0 +1,67 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/config"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/store"
+	"github.com/mongodb/mongocli/internal/usage"
+	"github.com/spf13/cobra"
+	"go.mongodb.org/ops-manager/atmcfg"
+)
+
+type EnableOpts struct {
+	cli.GlobalOpts
+	hostname string
+	store    store.AutomationPatcher
+}
+
+func (opts *EnableOpts) initStore() error {
+	var err error
+	opts.store, err = store.New(config.Default())
+	return err
+}
+
+func (opts *EnableOpts) Run() error {
+	current, err := opts.store.GetAutomationConfig(opts.ConfigProjectID())
+
+	if err != nil {
+		return err
+	}
+
+	if err := atmcfg.EnableBackup(current, opts.hostname); err != nil {
+		return err
+	}
+	if err := opts.store.UpdateAutomationConfig(opts.ConfigProjectID(), current); err != nil {
+		return err
+	}
+
+	fmt.Print(cli.DeploymentStatus(config.OpsManagerURL(), opts.ConfigProjectID()))
+
+	return nil
+}
+
+// mongocli ops-manager monitoring enable  [--projectId projectId]
+func EnableBuilder() *cobra.Command {
+	opts := &EnableOpts{}
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable monitoring for a given host",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(
+				opts.initStore,
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.hostname = args[0]
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+
+	return cmd
+}

--- a/internal/cli/opsmanager/backup/enable_test.go
+++ b/internal/cli/opsmanager/backup/enable_test.go
@@ -1,0 +1,50 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/fixture"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/mocks"
+)
+
+func TestEnableBuilder(t *testing.T) {
+	cli.CmdValidator(
+		t,
+		EnableBuilder(),
+		0,
+		[]string{flag.ProjectID},
+	)
+}
+
+func TestEnableOpts_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockAutomationPatcher(ctrl)
+	defer ctrl.Finish()
+
+	expected := fixture.AutomationConfig()
+
+	createOpts := &EnableOpts{
+		hostname: "test",
+		store:    mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		GetAutomationConfig(createOpts.ProjectID).
+		Return(expected, nil).
+		Times(1)
+
+	mockStore.
+		EXPECT().
+		UpdateAutomationConfig(createOpts.ProjectID, expected).
+		Return(nil).
+		Times(1)
+
+	err := createOpts.Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/opsmanager/monitoring/enable.go
+++ b/internal/cli/opsmanager/monitoring/enable.go
@@ -57,12 +57,12 @@ func (opts *EnableOpts) Run() error {
 	return nil
 }
 
-// mongocli ops-manager monitoring enable  [--projectId projectId]
+// mongocli ops-manager monitoring enable <hostname> [--projectId projectId]
 func EnableBuilder() *cobra.Command {
 	opts := &EnableOpts{}
 	cmd := &cobra.Command{
-		Use:   "enable",
-		Short: "Enable monitoring for a given host",
+		Use:   "enable <hostname>",
+		Short: "Enable monitoring for a given hostname",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/monitoring/enable.go
+++ b/internal/cli/opsmanager/monitoring/enable.go
@@ -1,0 +1,81 @@
+package monitoring
+
+import (
+	"fmt"
+
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/config"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/store"
+	"github.com/mongodb/mongocli/internal/usage"
+	"github.com/spf13/cobra"
+	"go.mongodb.org/ops-manager/atmcfg"
+)
+
+func Builder() *cobra.Command {
+	const use = "monitoring"
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: cli.GenerateAliases(use),
+		Short:   "Manage monitoring for your project.",
+	}
+
+	cmd.AddCommand(
+		EnableBuilder(),
+	)
+	return cmd
+}
+
+type EnableOpts struct {
+	cli.GlobalOpts
+	hostname string
+	store    store.AutomationPatcher
+}
+
+func (opts *EnableOpts) initStore() error {
+	var err error
+	opts.store, err = store.New(config.Default())
+	return err
+}
+
+func (opts *EnableOpts) Run() error {
+	current, err := opts.store.GetAutomationConfig(opts.ConfigProjectID())
+
+	if err != nil {
+		return err
+	}
+
+	if err := atmcfg.EnableMonitoring(current, opts.hostname); err != nil {
+		return err
+	}
+	if err := opts.store.UpdateAutomationConfig(opts.ConfigProjectID(), current); err != nil {
+		return err
+	}
+
+	fmt.Print(cli.DeploymentStatus(config.OpsManagerURL(), opts.ConfigProjectID()))
+
+	return nil
+}
+
+// mongocli ops-manager monitoring enable  [--projectId projectId]
+func EnableBuilder() *cobra.Command {
+	opts := &EnableOpts{}
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable monitoring for a given host",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(
+				opts.initStore,
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.hostname = args[0]
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+
+	return cmd
+}

--- a/internal/cli/opsmanager/monitoring/enable_test.go
+++ b/internal/cli/opsmanager/monitoring/enable_test.go
@@ -1,0 +1,59 @@
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/fixture"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/mocks"
+)
+
+func TestBuilder(t *testing.T) {
+	cli.CmdValidator(
+		t,
+		Builder(),
+		1,
+		[]string{},
+	)
+}
+
+func TestEnableBuilder(t *testing.T) {
+	cli.CmdValidator(
+		t,
+		EnableBuilder(),
+		0,
+		[]string{flag.ProjectID},
+	)
+}
+
+func TestEnableOpts_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockAutomationPatcher(ctrl)
+	defer ctrl.Finish()
+
+	expected := fixture.AutomationConfig()
+
+	createOpts := &EnableOpts{
+		hostname: "test",
+		store:    mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		GetAutomationConfig(createOpts.ProjectID).
+		Return(expected, nil).
+		Times(1)
+
+	mockStore.
+		EXPECT().
+		UpdateAutomationConfig(createOpts.ProjectID, expected).
+		Return(nil).
+		Times(1)
+
+	err := createOpts.Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/opsmanager/ops_manager.go
+++ b/internal/cli/opsmanager/ops_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/logs"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/maintenance"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/metrics"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/monitoring"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/owner"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/processes"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/security"
@@ -63,6 +64,7 @@ func Builder() *cobra.Command {
 		dbusers.Builder(),
 		owner.Builder(),
 		events.Builder(),
+		monitoring.Builder(),
 		processes.Builder(),
 		metrics.Builder(),
 		logs.Builder(),

--- a/internal/cli/opsmanager/ops_manager_test.go
+++ b/internal/cli/opsmanager/ops_manager_test.go
@@ -26,7 +26,7 @@ func TestBuilder(t *testing.T) {
 	cli.CmdValidator(
 		t,
 		Builder(),
-		16,
+		17,
 		[]string{},
 	)
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-73287

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments
```zsh
$ mongocli om monitoring enable host2
Changes are being applied, please check http://mms:8080/v2/5f43a927c74f75134f354a7a#deployment/topology for status
```

```zsh
$ mongocli om backup enable host2
Changes are being applied, please check http://mms:8080/v2/5f43a927c74f75134f354a7a#deployment/topology for status
```