### PR TITLE
CLOUDP-73535: Unhide and document automation config get and automation config update

### DIFF
--- a/internal/cli/opsmanager/automation/describe.go
+++ b/internal/cli/opsmanager/automation/describe.go
@@ -52,7 +52,6 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"show", "get"},
 		Short:   DescribeAutomationConfig,
 		Args:    cobra.NoArgs,
-		Hidden:  true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore,

--- a/internal/cli/opsmanager/automation/description.go
+++ b/internal/cli/opsmanager/automation/description.go
@@ -16,7 +16,7 @@ package automation
 const (
 	Automation               = "Manage automation configuration for your project."
 	ShowAutomationStatus     = "Show the current status of the automation config."
-	UpdateAutomationConfig   = "This operation is unsupported by mongocli, use at your own risk."
-	DescribeAutomationConfig = "This operation is unsupported by mongocli, use at your own risk."
+	UpdateAutomationConfig   = "Update the current automation configuration for a project."
+	DescribeAutomationConfig = "Get the current automation configuration for a project."
 	WatchAutomationStatus    = "Watch for automation changes to be completed."
 )

--- a/internal/cli/opsmanager/automation/update.go
+++ b/internal/cli/opsmanager/automation/update.go
@@ -63,9 +63,8 @@ func UpdateBuilder() *cobra.Command {
 		fs: afero.NewOsFs(),
 	}
 	cmd := &cobra.Command{
-		Use:    "update",
-		Hidden: true,
-		Short:  UpdateAutomationConfig,
+		Use:   "update",
+		Short: UpdateAutomationConfig,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initStore)
 		},


### PR DESCRIPTION

<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please be sure that you've reviewed our contributing guidelines: https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed the review along, and hopefully
the merge of your pull request!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-73535

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none
-->


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them,
don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Alternatively, if this is a very minor, and self-explanitory change, feel free to remove this section.
-->

```
./bin/mongocli om automation
Manage automation configuration for your project.

Usage:
  mongocli ops-manager automation [command]

Available Commands:
  status      Show the current status of the automation config.
  describe    Get the current automation configuration for a project.
  update      Update the current automation configuration for a project.
  watch       Watch for automation changes to be completed.

Flags:
  -h, --help   help for automation

Global Flags:
  -P, --profile string   Profile to use from your configuration file.

Use "mongocli ops-manager automation [command] --help" for more information about a command.
```
