### PR TITLE
CLOUDP-73709: mongocli brew permissions issue for Linux TGZ - 1.5 & 1.6

### DIFF
--- a/build/package/generate-notices.sh
+++ b/build/package/generate-notices.sh
@@ -27,3 +27,4 @@ go get github.com/google/go-licenses
 popd
 
 go-licenses save "github.com/mongodb/mongocli/cmd/mongocli" --save_path=third_party_notices
+sudo chmod -R 755 ./third_party_notices

--- a/build/package/generate-notices.sh
+++ b/build/package/generate-notices.sh
@@ -27,4 +27,5 @@ go get github.com/google/go-licenses
 popd
 
 go-licenses save "github.com/mongodb/mongocli/cmd/mongocli" --save_path=third_party_notices
+# For HCL, a dependency of viper, go-license adds the source code with restricted permissions, this is a problem for some linux users
 sudo chmod -R 755 ./third_party_notices


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-73709


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

