### PR TITLE
CLOUDP-77170: [mongocli] Preserve args_26 maps when updating a cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tangzero/inflector v1.0.0
 	go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2
-	go.mongodb.org/ops-manager v0.13.0
+	go.mongodb.org/ops-manager v0.13.1
 	golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a // indirect
 	golang.org/x/sys v0.0.0-20200523222454-059865788121 // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2 h1:b4Ng7d2sCSgYKwLMOetbwLcPE732SiBnJqH5rQrhZOs=
 go.mongodb.org/atlas v0.5.1-0.20201007214134-b315fe7503d2/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
-go.mongodb.org/ops-manager v0.13.0 h1:KRZWr4G10RLXTLpnCKy96T6WpyPjr+jMVEbA7YjVgQA=
-go.mongodb.org/ops-manager v0.13.0/go.mod h1:elCFWG6rDmQNAL0tF0lQnN3XEwwNuPeeZD1VtIocqCk=
+go.mongodb.org/ops-manager v0.13.1 h1:aFxVffO+NyR5OqZQgx8eTLqIiNXl6SbzY2SFqG6gt/M=
+go.mongodb.org/ops-manager v0.13.1/go.mod h1:elCFWG6rDmQNAL0tF0lQnN3XEwwNuPeeZD1VtIocqCk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/convert/cluster_config.go
+++ b/internal/convert/cluster_config.go
@@ -161,12 +161,35 @@ func patchProcesses(out *opsmngr.AutomationConfig, newReplicaSetID string, newPr
 			return p.Name == oldName
 		})
 		if found {
+			keepSettings(oldProcess, newProcesses, pos)
 			out.Processes[i] = newProcesses[pos]
 			newProcesses = append(newProcesses[:pos], newProcesses[pos+1:]...)
 		}
 	}
 	if len(newProcesses) > 0 {
 		out.Processes = append(out.Processes, newProcesses...)
+	}
+}
+
+// keepSettings if the process exists keep settings we don't expose via the CLI config file
+func keepSettings(oldProcess *opsmngr.Process, newProcesses []*opsmngr.Process, pos int) {
+	if oldProcess.Args26.BasisTech != nil {
+		newProcesses[pos].Args26.BasisTech = oldProcess.Args26.BasisTech
+	}
+	if oldProcess.Args26.OperationProfiling != nil {
+		newProcesses[pos].Args26.OperationProfiling = oldProcess.Args26.OperationProfiling
+	}
+	if oldProcess.Args26.ProcessManagement != nil {
+		newProcesses[pos].Args26.ProcessManagement = oldProcess.Args26.ProcessManagement
+	}
+	if oldProcess.Args26.Security != nil {
+		newProcesses[pos].Args26.Security = oldProcess.Args26.Security
+	}
+	if oldProcess.Args26.SetParameter != nil {
+		newProcesses[pos].Args26.SetParameter = oldProcess.Args26.SetParameter
+	}
+	if oldProcess.Args26.SNMP != nil {
+		newProcesses[pos].Args26.SNMP = oldProcess.Args26.SNMP
 	}
 }
 

--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -173,6 +173,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: "file",
 								Path:        "/data/db/mongodb.log",
 							},
+							Security: &map[string]interface{}{
+								"test": "test",
+							},
 						},
 						LogRotate: &opsmngr.LogRotate{
 							SizeThresholdMB:  1000,
@@ -315,6 +318,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 								Destination: "file",
 								Path:        "/data/db/mongodb.log",
 							},
+							Security: &map[string]interface{}{
+								"test": "test",
+							},
 						},
 						LogRotate: &opsmngr.LogRotate{
 							SizeThresholdMB:  1000,
@@ -439,6 +445,9 @@ func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
 							SystemLog: opsmngr.SystemLog{
 								Destination: "file",
 								Path:        "/data/db/mongodb.log",
+							},
+							Security: &map[string]interface{}{
+								"test": "test",
 							},
 						},
 						LogRotate: &opsmngr.LogRotate{

--- a/internal/fixture/automation_configs.go
+++ b/internal/fixture/automation_configs.go
@@ -14,7 +14,16 @@
 
 package fixture
 
-import "go.mongodb.org/ops-manager/opsmngr"
+import (
+	"go.mongodb.org/ops-manager/opsmngr"
+)
+
+const (
+	defaultMongoDPort        = 27017
+	defaultTimeThresholdHrs  = 24
+	defaultAuthSchemaVersion = 5
+	defaultSizeThresholdMB   = 1000
+)
 
 func AutomationConfig() *opsmngr.AutomationConfig {
 	return &opsmngr.AutomationConfig{
@@ -28,15 +37,13 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 				Name:                        "myReplicaSet_1",
 				ProcessType:                 "mongod",
 				Version:                     "4.2.2",
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				FeatureCompatibilityVersion: "4.2",
 				Disabled:                    false,
 				ManualMode:                  false,
 				Hostname:                    "host0",
 				Args26: opsmngr.Args26{
-					NET: opsmngr.Net{
-						Port: 27000,
-					},
+					NET: opsmngr.Net{Port: 27000},
 					Storage: &opsmngr.Storage{
 						DBPath: "/data/rs1",
 					},
@@ -49,8 +56,8 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 					},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000.0,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				LastGoalVersionAchieved: 0,
 				Cluster:                 "",
@@ -59,15 +66,13 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 				Name:                        "myReplicaSet_2",
 				ProcessType:                 "mongod",
 				Version:                     "4.2.2",
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				FeatureCompatibilityVersion: "4.2",
 				Disabled:                    false,
 				ManualMode:                  false,
 				Hostname:                    "host1",
 				Args26: opsmngr.Args26{
-					NET: opsmngr.Net{
-						Port: 27010,
-					},
+					NET: opsmngr.Net{Port: 27010},
 					Storage: &opsmngr.Storage{
 						DBPath: "/data/rs2",
 					},
@@ -80,8 +85,8 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 					},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000.0,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				LastGoalVersionAchieved: 0,
 				Cluster:                 "",
@@ -90,15 +95,13 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 				Name:                        "myReplicaSet_3",
 				ProcessType:                 "mongod",
 				Version:                     "4.2.2",
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				FeatureCompatibilityVersion: "4.2",
 				Disabled:                    false,
 				ManualMode:                  false,
 				Hostname:                    "host0",
 				Args26: opsmngr.Args26{
-					NET: opsmngr.Net{
-						Port: 27020,
-					},
+					NET: opsmngr.Net{Port: 27020},
 					Storage: &opsmngr.Storage{
 						DBPath: "/data/rs3",
 					},
@@ -111,8 +114,8 @@ func AutomationConfig() *opsmngr.AutomationConfig {
 					},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000.0,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				LastGoalVersionAchieved: 0,
 				Cluster:                 "",
@@ -166,7 +169,7 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 			{
 				Args26: opsmngr.Args26{
 					NET: opsmngr.Net{
-						Port: 27017,
+						Port: defaultMongoDPort,
 						TLS: &opsmngr.TLS{
 							CAFile:                     "CAFile",
 							CertificateKeyFile:         "CertificateKeyFile",
@@ -189,19 +192,23 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 					Storage: &opsmngr.Storage{
 						DBPath: "/data/db/",
 					},
+
+					Security: &map[string]interface{}{
+						"test": "test",
+					},
 					SystemLog: opsmngr.SystemLog{
 						Destination: "file",
 						Path:        "/data/db/mongodb.log",
 					},
 				},
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				Name:                        name + "_0",
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host0",
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				ProcessType: "mongod",
 				Version:     "4.2.2",
@@ -248,10 +255,10 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				Name:                        name + "_myShard_0_0",
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
@@ -276,10 +283,10 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					Sharding: &opsmngr.Sharding{ClusterRole: "configsvr"},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				Name:                        name + "_configRS_1",
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
@@ -297,11 +304,11 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					},
 				},
 				LogRotate: &opsmngr.LogRotate{
-					SizeThresholdMB:  1000,
-					TimeThresholdHrs: 24,
+					SizeThresholdMB:  defaultSizeThresholdMB,
+					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				Cluster:                     name,
-				AuthSchemaVersion:           5,
+				AuthSchemaVersion:           defaultAuthSchemaVersion,
 				Name:                        name + "_mongos_2",
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-77170

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

