### PR TITLE
CLOUDP-77819: mongocli om process ls is all one line

### DIFF
--- a/internal/cli/opsmanager/processes/list.go
+++ b/internal/cli/opsmanager/processes/list.go
@@ -39,7 +39,8 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
-var listTemplate = `ID	TYPE	HOSTNAME	STATE NAME	PORT{{range .Results}}{{.ID}}	{{.TypeName}}	{{.ReplicaStateName}} {{.Hostname}}	{{.Port}}{{end}}
+var listTemplate = `ID	TYPE	HOSTNAME	STATE NAME	PORT{{range .Results}}
+{{.ID}}	{{.TypeName}}	{{.Hostname}}	{{.ReplicaStateName}}	{{.Port}}{{end}}
 `
 
 func (opts *ListOpts) Run() error {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-77819

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This change sneaked in when I changed the usage, this si a quick fix for the output