### PR TITLE
CLOUDP-78065: [mongocli] atlas logs download doesn’t work if --out is not provided

### DIFF
--- a/e2e/atlas/helper_test.go
+++ b/e2e/atlas/helper_test.go
@@ -49,6 +49,7 @@ const (
 	ldapEntity             = "ldap"
 	awsEntity              = "aws"
 	customDNSEntity        = "customDns"
+	logsEntity             = "logs"
 )
 
 func getHostnameAndPort() (string, error) {

--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestLogs(t *testing.T) {
-	const logsEntity = "logs"
-
 	clusterName, err := deployCluster()
 	if err != nil {
 		t.Fatalf("failed to deploy a cluster: %v", err)
@@ -47,125 +45,72 @@ func TestLogs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Run("Download mongodb.gz", func(t *testing.T) {
-		dir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-		logFile := "mongodb.gz"
-		filepath := dir + logFile
-
-		cmd := exec.Command(cliPath,
-			atlasEntity,
-			logsEntity,
-			"download",
-			hostname,
-			logFile,
-			"--out",
-			filepath,
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		if _, err := os.Stat(filepath); err != nil {
-			t.Fatalf("%v has not been downloaded", filepath)
-		}
+		downloadLogTmpPath(t, cliPath, hostname, "mongodb.gz")
 	})
 
 	t.Run("Download mongos.gz", func(t *testing.T) {
-		dir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		logFile := "mongos.gz"
-		filepath := dir + logFile
-
-		cmd := exec.Command(cliPath,
-			atlasEntity,
-			logsEntity,
-			"download",
-			hostname,
-			logFile,
-			"--out",
-			filepath,
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		if _, err := os.Stat(filepath); err != nil {
-			t.Fatalf("%v has not been downloaded", filepath)
-		}
+		downloadLogTmpPath(t, cliPath, hostname, "mongos.gz")
 	})
 
 	t.Run("Download mongodb-audit-log.gz", func(t *testing.T) {
-		dir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		logFile := "mongodb-audit-log.gz"
-		filepath := dir + logFile
-
-		cmd := exec.Command(cliPath,
-			atlasEntity,
-			logsEntity,
-			"download",
-			hostname,
-			logFile,
-			"--out",
-			filepath,
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		if _, err := os.Stat(filepath); err != nil {
-			t.Fatalf("%v has not been downloaded", filepath)
-		}
+		downloadLogTmpPath(t, cliPath, hostname, "mongodb-audit-log.gz")
 	})
 
 	t.Run("Download mongos-audit-log.gz", func(t *testing.T) {
-		dir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		logFile := "mongos-audit-log.gz"
-		filepath := dir + logFile
-
-		cmd := exec.Command(cliPath,
-			atlasEntity,
-			logsEntity,
-			"download",
-			hostname,
-			logFile,
-			"--out",
-			filepath,
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		if _, err := os.Stat(filepath); err != nil {
-			t.Fatalf("%v has not been downloaded", filepath)
-		}
+		downloadLogTmpPath(t, cliPath, hostname, "mongos-audit-log.gz")
 	})
+
+	t.Run("Download mongodb.gz no output path", func(t *testing.T) {
+		downloadLog(t, cliPath, hostname, "mongodb.gz")
+	})
+}
+
+func downloadLogTmpPath(t *testing.T, cliPath, hostname, logFile string) {
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	filepath := dir + logFile
+
+	cmd := exec.Command(cliPath,
+		atlasEntity,
+		logsEntity,
+		"download",
+		hostname,
+		logFile,
+		"--out",
+		filepath,
+	)
+
+	cmd.Env = os.Environ()
+	resp, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
+	}
+
+	if _, err := os.Stat(filepath); err != nil {
+		t.Fatalf("%v has not been downloaded", filepath)
+	}
+}
+
+func downloadLog(t *testing.T, cliPath, hostname, logFile string) {
+	cmd := exec.Command(cliPath,
+		atlasEntity,
+		logsEntity,
+		"download",
+		hostname,
+		logFile,
+	)
+
+	cmd.Env = os.Environ()
+	resp, err := cmd.CombinedOutput()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
+	}
+
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("%v has not been downloaded", logFile)
+	}
 }

--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"
@@ -110,7 +111,8 @@ func downloadLog(t *testing.T, cliPath, hostname, logFile string) {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 	}
 
-	if _, err := os.Stat(logFile); err != nil {
+	outputFile := strings.ReplaceAll(logFile, ".gz", ".log.gz")
+	if _, err := os.Stat(outputFile); err != nil {
 		t.Fatalf("%v has not been downloaded", logFile)
 	}
 }

--- a/internal/cli/atlas/logs/download.go
+++ b/internal/cli/atlas/logs/download.go
@@ -65,10 +65,11 @@ func (opts *DownloadOpts) Run() error {
 	return f.Close()
 }
 
-func (opts *DownloadOpts) initDefaultOut() {
+func (opts *DownloadOpts) initDefaultOut() error {
 	if opts.Out == "" {
 		opts.Out = strings.ReplaceAll(opts.name, ".gz", ".log.gz")
 	}
+	return nil
 }
 
 func (opts *DownloadOpts) newDateRangeOpts() *atlas.DateRangetOptions {
@@ -89,12 +90,11 @@ func DownloadBuilder() *cobra.Command {
 		Long:  downloadLong,
 		Args:  require.ExactArgs(argsN),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.initDefaultOut()
-			return opts.PreRunE(opts.ValidateProjectID, opts.initStore)
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.host = args[0]
 			opts.name = args[1]
+			return opts.PreRunE(opts.ValidateProjectID, opts.initStore, opts.initDefaultOut)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if !search.StringInSlice(cmd.ValidArgs, opts.name) {
 				return fmt.Errorf("<logname> must be one of %s", cmd.ValidArgs)
 			}

--- a/internal/cli/atlas/logs/download_test.go
+++ b/internal/cli/atlas/logs/download_test.go
@@ -95,8 +95,9 @@ func TestDownloadOpts_initDefaultOut(t *testing.T) {
 				name: logName,
 			}
 			opts.Out = out
-			opts.initDefaultOut()
-			assert.Equal(t, opts.Out, want)
+			a := assert.New(t)
+			a.NoError(opts.initDefaultOut())
+			a.Equal(opts.Out, want)
 		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-78065

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
