### PR TITLE
CLOUDP-80279: Add a confirmation message to Deauthorize a Cloud Provider Access Role

### DIFF
--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -79,7 +79,9 @@ func DeauthorizeBuilder() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Entry = args[0]
-			opts.CustomizedPrompt(confirmationMessage)
+			if err := opts.CustomizedPrompt(confirmationMessage); err != nil {
+				return err
+			}
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -79,7 +79,7 @@ func DeauthorizeBuilder() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Entry = args[0]
-			if err := opts.CustomizedPrompt(confirmationMessage); err != nil {
+			if err := opts.PromptWithMessage(confirmationMessage); err != nil {
 				return err
 			}
 			return opts.Run()

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -28,7 +28,7 @@ import (
 const (
 	deauthorizeSuccess  = "AWS IAM role successfully deauthorized.\n"
 	deauthorizeFail     = "AWS IAM role not deauthorized.\n"
-	confirmationMessage = "Are you sure you want to deauthorize"
+	confirmationMessage = "Are you sure you want to deauthorize: %s"
 )
 
 type DeauthorizeOpts struct {
@@ -75,13 +75,11 @@ func DeauthorizeBuilder() *cobra.Command {
 		Short: deauthorize,
 		Args:  require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore); err != nil {
-				return err
-			}
-			opts.Entry = args[0]
-			return opts.CustomizedPrompt(confirmationMessage)
+			return opts.PreRunE(opts.ValidateProjectID, opts.initStore)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Entry = args[0]
+			opts.CustomizedPrompt(confirmationMessage)
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/flag"
 	"github.com/mongodb/mongocli/internal/mocks"
 	"github.com/mongodb/mongocli/internal/test"
@@ -32,6 +33,10 @@ func TestDeauthorizeOpts_Run(t *testing.T) {
 
 	opts := &DeauthorizeOpts{
 		store: mockStore,
+		DeleteOpts: &cli.DeleteOpts{
+			Entry:   "to_delete",
+			Confirm: true,
+		},
 	}
 
 	mockStore.
@@ -51,6 +56,6 @@ func TestDeauthorizeBuilder(t *testing.T) {
 		t,
 		DeauthorizeBuilder(),
 		0,
-		[]string{flag.ProjectID, flag.Output},
+		[]string{flag.ProjectID, flag.Force},
 	)
 }

--- a/internal/cli/delete_opts.go
+++ b/internal/cli/delete_opts.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,6 +80,16 @@ func (opts *DeleteOpts) Prompt() error {
 	}
 
 	p := prompt.NewDeleteConfirm(opts.Entry)
+	return survey.AskOne(p, &opts.Confirm)
+}
+
+// CustomizedPrompt confirms that the resource should be deleted
+func (opts *DeleteOpts) CustomizedPrompt(message string) error {
+	if opts.Confirm {
+		return nil
+	}
+
+	p := prompt.NewCustomizeConfirm(message, opts.Entry)
 	return survey.AskOne(p, &opts.Confirm)
 }
 

--- a/internal/cli/delete_opts.go
+++ b/internal/cli/delete_opts.go
@@ -89,7 +89,7 @@ func (opts *DeleteOpts) PromptWithMessage(message string) error {
 		return nil
 	}
 
-	p := prompt.NewConfirm(message, opts.Entry)
+	p := prompt.NewConfirm(fmt.Sprintf(message, opts.Entry))
 	return survey.AskOne(p, &opts.Confirm)
 }
 

--- a/internal/cli/delete_opts.go
+++ b/internal/cli/delete_opts.go
@@ -83,13 +83,13 @@ func (opts *DeleteOpts) Prompt() error {
 	return survey.AskOne(p, &opts.Confirm)
 }
 
-// CustomizedPrompt confirms that the resource should be deleted
-func (opts *DeleteOpts) CustomizedPrompt(message string) error {
+// PromptWithMessage confirms that the resource should be deleted
+func (opts *DeleteOpts) PromptWithMessage(message string) error {
 	if opts.Confirm {
 		return nil
 	}
 
-	p := prompt.NewCustomizeConfirm(message, opts.Entry)
+	p := prompt.NewConfirm(message, opts.Entry)
 	return survey.AskOne(p, &opts.Confirm)
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -31,7 +31,7 @@ func NewDeleteConfirm(entry string) survey.Prompt {
 // NewCustomizeConfirm creates a prompt to confirm if the entry should be deleted
 func NewCustomizeConfirm(message, entry string) survey.Prompt {
 	prompt := &survey.Confirm{
-		Message: fmt.Sprintf("%s %s", message, entry),
+		Message: fmt.Sprintf(message, entry),
 	}
 	return prompt
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,14 @@ import (
 func NewDeleteConfirm(entry string) survey.Prompt {
 	prompt := &survey.Confirm{
 		Message: fmt.Sprintf("Are you sure you want to delete: %s", entry),
+	}
+	return prompt
+}
+
+// NewCustomizeConfirm creates a prompt to confirm if the entry should be deleted
+func NewCustomizeConfirm(message, entry string) survey.Prompt {
+	prompt := &survey.Confirm{
+		Message: fmt.Sprintf("%s %s", message, entry),
 	}
 	return prompt
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -29,9 +29,9 @@ func NewDeleteConfirm(entry string) survey.Prompt {
 }
 
 // NewConfirm creates a prompt to confirm if the entry should be deleted
-func NewConfirm(message, entry string) survey.Prompt {
+func NewConfirm(message string) survey.Prompt {
 	prompt := &survey.Confirm{
-		Message: fmt.Sprintf(message, entry),
+		Message: message,
 	}
 	return prompt
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -28,8 +28,8 @@ func NewDeleteConfirm(entry string) survey.Prompt {
 	return prompt
 }
 
-// NewCustomizeConfirm creates a prompt to confirm if the entry should be deleted
-func NewCustomizeConfirm(message, entry string) survey.Prompt {
+// NewConfirm creates a prompt to confirm if the entry should be deleted
+func NewConfirm(message, entry string) survey.Prompt {
 	prompt := &survey.Confirm{
 		Message: fmt.Sprintf(message, entry),
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-80279

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

```
 ./bin/mongocli atlas cloudProviders accessRoles aws deauthorize 5ffd8cc17bd5c049ef1c88f5
? Are you sure you want to deauthorize 5ffd8cc17bd5c049ef1c88f5 Yes
AWS IAM role successfully deauthorized.
```

```
 ./bin/mongocli atlas cloudProviders accessRoles aws deauthorize 5ffd898d15a4f913021b9305
? Are you sure you want to deauthorize 5ffd898d15a4f913021b9305 No
AWS IAM role not deauthorized.
```