### PR TITLE
CLOUDP-79631: Retrieve details for all private endpoint service for AWS or Azure in an Atlas project

### DIFF
--- a/internal/cli/atlas/privateendpoints/list.go
+++ b/internal/cli/atlas/privateendpoints/list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,14 +25,15 @@ import (
 )
 
 var listTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR{{range .}}
-{{.ID}}	{{.EndpointServiceName}}	{{.Status}}	{{.ErrorMessage}}{{end}}
+{{.ID}}{{if .EndpointServiceName}}	{{.EndpointServiceName}}{{else}}	PrivateLinkServiceName{{end}}	{{.Status}}	{{.ErrorMessage}}{{end}}
 `
 
 type ListOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
 	cli.ListOpts
-	store store.PrivateEndpointLister
+	store    store.PrivateEndpointLister
+	provider string
 }
 
 func (opts *ListOpts) init() error {
@@ -42,7 +43,7 @@ func (opts *ListOpts) init() error {
 }
 
 func (opts *ListOpts) Run() error {
-	r, err := opts.store.PrivateEndpoints(opts.ConfigProjectID(), opts.NewListOptions())
+	r, err := opts.store.PrivateEndpoints(opts.ConfigProjectID(), opts.provider, opts.NewListOptions())
 
 	if err != nil {
 		return err
@@ -70,6 +71,8 @@ func ListBuilder() *cobra.Command {
 			return opts.Run()
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.provider, flag.Provider, "AWS", usage.ProviderPrivateEndpoint)
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, 0, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, 0, usage.Limit)

--- a/internal/cli/atlas/privateendpoints/list_test.go
+++ b/internal/cli/atlas/privateendpoints/list_test.go
@@ -19,11 +19,10 @@ package privateendpoints
 import (
 	"testing"
 
-	"github.com/mongodb/mongocli/internal/flag"
-	"github.com/mongodb/mongocli/internal/test"
-
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongocli/internal/flag"
 	"github.com/mongodb/mongocli/internal/mocks"
+	"github.com/mongodb/mongocli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
 )

--- a/internal/cli/atlas/privateendpoints/list_test.go
+++ b/internal/cli/atlas/privateendpoints/list_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ package privateendpoints
 import (
 	"testing"
 
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/test"
+
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongocli/internal/mocks"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +33,7 @@ func TestList_Run(t *testing.T) {
 	mockStore := mocks.NewMockPrivateEndpointLister(ctrl)
 	defer ctrl.Finish()
 
-	var expected []mongodbatlas.PrivateEndpointConnectionDeprecated
+	var expected []mongodbatlas.PrivateEndpointConnection
 
 	listOpts := &ListOpts{
 		store: mockStore,
@@ -38,10 +41,19 @@ func TestList_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		PrivateEndpoints(listOpts.ProjectID, listOpts.NewListOptions()).
+		PrivateEndpoints(listOpts.ProjectID, listOpts.provider, listOpts.NewListOptions()).
 		Return(expected, nil).
 		Times(1)
 
 	err := listOpts.Run()
 	assert.NoError(t, err)
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{flag.ProjectID, flag.Output, flag.Page, flag.Provider, flag.Limit},
+	)
 }

--- a/internal/mocks/mock_private_endpoints.go
+++ b/internal/mocks/mock_private_endpoints.go
@@ -34,18 +34,18 @@ func (m *MockPrivateEndpointLister) EXPECT() *MockPrivateEndpointListerMockRecor
 }
 
 // PrivateEndpoints mocks base method
-func (m *MockPrivateEndpointLister) PrivateEndpoints(arg0 string, arg1 *mongodbatlas.ListOptions) ([]mongodbatlas.PrivateEndpointConnectionDeprecated, error) {
+func (m *MockPrivateEndpointLister) PrivateEndpoints(arg0, arg1 string, arg2 *mongodbatlas.ListOptions) ([]mongodbatlas.PrivateEndpointConnection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrivateEndpoints", arg0, arg1)
-	ret0, _ := ret[0].([]mongodbatlas.PrivateEndpointConnectionDeprecated)
+	ret := m.ctrl.Call(m, "PrivateEndpoints", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]mongodbatlas.PrivateEndpointConnection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrivateEndpoints indicates an expected call of PrivateEndpoints
-func (mr *MockPrivateEndpointListerMockRecorder) PrivateEndpoints(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPrivateEndpointListerMockRecorder) PrivateEndpoints(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateEndpoints", reflect.TypeOf((*MockPrivateEndpointLister)(nil).PrivateEndpoints), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateEndpoints", reflect.TypeOf((*MockPrivateEndpointLister)(nil).PrivateEndpoints), arg0, arg1, arg2)
 }
 
 // MockPrivateEndpointDescriber is a mock of PrivateEndpointDescriber interface

--- a/internal/store/private_endpoints.go
+++ b/internal/store/private_endpoints.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/store/private_endpoints.go
+++ b/internal/store/private_endpoints.go
@@ -25,7 +25,7 @@ import (
 //go:generate mockgen -destination=../mocks/mock_private_endpoints.go -package=mocks github.com/mongodb/mongocli/internal/store PrivateEndpointLister,PrivateEndpointDescriber,PrivateEndpointCreator,PrivateEndpointDeleter,InterfaceEndpointDescriber,InterfaceEndpointCreator,InterfaceEndpointDeleter
 
 type PrivateEndpointLister interface {
-	PrivateEndpoints(string, *atlas.ListOptions) ([]atlas.PrivateEndpointConnectionDeprecated, error)
+	PrivateEndpoints(string, string, *atlas.ListOptions) ([]atlas.PrivateEndpointConnection, error)
 }
 
 type PrivateEndpointDescriber interface {
@@ -53,10 +53,10 @@ type InterfaceEndpointDeleter interface {
 }
 
 // PrivateEndpoints encapsulates the logic to manage different cloud providers
-func (s *Store) PrivateEndpoints(projectID string, opts *atlas.ListOptions) ([]atlas.PrivateEndpointConnectionDeprecated, error) {
+func (s *Store) PrivateEndpoints(projectID, provider string, opts *atlas.ListOptions) ([]atlas.PrivateEndpointConnection, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).PrivateEndpointsDeprecated.List(context.Background(), projectID, opts)
+		result, _, err := s.client.(*atlas.Client).PrivateEndpoints.List(context.Background(), projectID, provider, opts)
 		return result, err
 	default:
 		return nil, fmt.Errorf("unsupported service: %s", s.service)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -268,6 +268,8 @@ Valid values: cidrBlock|ipAddress|awsSecurityGroup`
 Valid values: cloud|cloud-manager|ops-manager`
 	Provider = `Name of your cloud service provider.
 Valid values: AWS|AZURE|GCP.`
+	ProviderPrivateEndpoint = `Name of your cloud service provider.
+Valid values: AWS|AZURE.`
 	ClusterTypes = `Type of the cluster that you want to create.
 Valid values: REPLICASET|SHARDED.`
 	Region = `Physical location of your MongoDB cluster.


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-79631

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

```
./bin/mongocli atlas privateEndpoint list
ID                         ENDPOINT SERVICE                                          STATUS             ERROR
5f3fb2c58ef2cb1c795cddbb   com.amazonaws.vpce.us-east-2.vpce-svc-09c771f7ad2a628e8   WAITING_FOR_USER
5f999db19900d15068d425c9   com.amazonaws.vpce.us-east-1.vpce-svc-079752da00a0d26a4   WAITING_FOR_USER
5fff12b1fd7c32762a6d7e30   com.amazonaws.vpce.eu-west-1.vpce-svc-074a4307981953ad4   WAITING_FOR_USER
```

```
./bin/mongocli atlas privateEndpoint list --provider AZURE
ID                         ENDPOINT SERVICE         STATUS      ERROR
5fff120253b6064ef7de897e   PrivateLinkServiceName   AVAILABLE
```

```
./bin/mongocli atlas privateEndpoint list --provider AZURE -o json
[
  {
    "id": "5fff120253b6064ef7de897e",
    "privateLinkServiceName": "pls_5fff120253b6064ef7de897e",
    "privateLinkServiceResourceId": "/subscriptions/4e133d35-e734-4380-a565-c0945535da37/resourceGroups/rg_5fff120253b6064ef7de897f_2ieuzpfm/providers/Microsoft.Network/privateLinkServices/pls_5fff120253b6064ef7de897e",
    "status": "AVAILABLE"
  }
]
```