### PR TITLE
CLOUDP-80528: mongocli server usage organiation host ls pointing to project

### DIFF
--- a/internal/cli/opsmanager/serverusage/organizations/organizations.go
+++ b/internal/cli/opsmanager/serverusage/organizations/organizations.go
@@ -17,7 +17,7 @@ package organizations
 import (
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/organizations/servertype"
-	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/projects/hosts"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/organizations/hosts"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/opsmanager/serverusage/organizations/organizations.go
+++ b/internal/cli/opsmanager/serverusage/organizations/organizations.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2021 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@ package organizations
 
 import (
 	"github.com/mongodb/mongocli/internal/cli"
-	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/organizations/servertype"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/organizations/hosts"
+	"github.com/mongodb/mongocli/internal/cli/opsmanager/serverusage/organizations/servertype"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-80528

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
`mongocli server usage organization host ls` does not work. The error is due to `organization.go` pointing to the wrong command.

