### PR TITLE
CLOUDP-80762: mongocli om featurePolicies list return an error if not policies are defined in the project

### DIFF
--- a/internal/cli/opsmanager/featurepolicies/list.go
+++ b/internal/cli/opsmanager/featurepolicies/list.go
@@ -36,8 +36,8 @@ func (opts *ListOpts) initStore() error {
 }
 
 var listTemplate = `NAME	SYSTEM ID	POLICY
-{{- $name := .ExternalManagementSystem.Name }}{{- $systemID := .ExternalManagementSystem.SystemID }}{{- range .Policies}}	
-{{ $name }}	{{ $systemID }}	{{.Policy}}{{end}}
+{{if .ExternalManagementSystem}}{{- $name := .ExternalManagementSystem.Name }}{{- $systemID := .ExternalManagementSystem.SystemID }}{{- range .Policies}}	
+{{ $name }}	{{ $systemID }}	{{.Policy}}{{end}}{{end}}
 `
 
 func (opts *ListOpts) Run() error {


### PR DESCRIPTION


<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-80762

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

Error:
```
mongocli om featurePolicies list -P om
Error: template: output:2:38: executing "output" at <.ExternalManagementSystem.Name>: nil pointer evaluating *opsmngr.ExternalManagementSystem.Name
```


Fix:
```
./bin/mongocli om featurePolicies list -P ops
NAME   SYSTEM ID   POLICY
```

