### PR TITLE
CLOUDP-81627: Improve Atlas cluster create dynamic version for limited internet envs

### DIFF
--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -89,13 +89,13 @@ func rootBuilder() {
 		rootCmd.AddCommand(atlas.Builder())
 	}
 	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == cloudmanager.Use {
-		cloudmanager.Builder()
+		rootCmd.AddCommand(cloudmanager.Builder())
 	}
 	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == opsmanager.Use {
-		opsmanager.Builder()
+		rootCmd.AddCommand(opsmanager.Builder())
 	}
 	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == iam.Use {
-		iam.Builder()
+		rootCmd.AddCommand(iam.Builder())
 	}
 	rootCmd.AddCommand(
 		completionCmd,

--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -32,6 +32,8 @@ import (
 )
 
 var (
+	profile string
+
 	rootCmd = cli.Builder()
 
 	completionCmd = &cobra.Command{
@@ -65,30 +67,40 @@ no additional shell configuration is necessary, see https://docs.brew.sh/Shell-C
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	rootBuilder()
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
 
-var (
-	profile string
-)
+// rootBuilder conditionally adds children commands as needed.
+// This is important in particular for Atlas as it dynamically sets flags for cluster creation and
+// this can be slow to timeout on environments with limited internet access (Ops Manager)
+func rootBuilder() {
+	argsWithoutProg := os.Args[1:]
+	if len(argsWithoutProg) != 0 && argsWithoutProg[0] == "--version" {
+		return
+	}
+	rootCmd.AddCommand(cliconfig.Builder())
 
-func init() { //nolint:gochecknoinits // This is the cobra way
+	// We realistically only care about not adding Atlas to the chain of commands
+	// but given we can reuse the pattern for the rest we can save some initialization time here
+	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == atlas.Use {
+		rootCmd.AddCommand(atlas.Builder())
+	}
+	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == cloudmanager.Use {
+		cloudmanager.Builder()
+	}
+	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == opsmanager.Use {
+		opsmanager.Builder()
+	}
+	if len(argsWithoutProg) == 0 || argsWithoutProg[0] == iam.Use {
+		iam.Builder()
+	}
 	rootCmd.AddCommand(
-		cliconfig.Builder(),
-		atlas.Builder(),
-		cloudmanager.Builder(),
-		opsmanager.Builder(),
-		iam.Builder(),
 		completionCmd,
 	)
-
-	cobra.EnableCommandSorting = false
-
 	rootCmd.PersistentFlags().StringVarP(&profile, flag.Profile, flag.ProfileShort, "", usage.Profile)
-
-	cobra.OnInitialize(initConfig)
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -106,5 +118,8 @@ func initConfig() {
 }
 
 func main() {
+	cobra.EnableCommandSorting = false
+	cobra.OnInitialize(initConfig)
+
 	Execute()
 }

--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -39,11 +39,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const atlasShort = "Atlas operations."
+const (
+	Use        = "atlas"
+	atlasShort = "Atlas operations."
+)
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "atlas",
+		Use:   Use,
 		Short: atlasShort,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			config.SetService(config.CloudService)

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -257,5 +257,7 @@ func DefaultMongoDBMajorVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return s.DefaultMongoDBVersion()
+	defaultMongoDBMajorVersion, _ = s.DefaultMongoDBVersion()
+
+	return defaultMongoDBMajorVersion, nil
 }

--- a/internal/cli/cloudmanager/cloud_manager.go
+++ b/internal/cli/cloudmanager/cloud_manager.go
@@ -36,11 +36,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const cloudManager = "MongoDB Cloud Manager operations."
+const (
+	Use          = "cloud-manager"
+	cloudManager = "MongoDB Cloud Manager operations."
+)
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "cloud-manager",
+		Use:     Use,
 		Aliases: []string{"cm"},
 		Short:   cloudManager,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/iam.go
+++ b/internal/cli/iam/iam.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
+	Use  = "iam"
 	iam  = "Organization and projects operations."
 	long = "Identity and Access Management."
 )
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "iam",
+		Use: Use,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return validate.Credentials()
 		},

--- a/internal/cli/opsmanager/ops_manager.go
+++ b/internal/cli/opsmanager/ops_manager.go
@@ -42,11 +42,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const opsManager = "Ops Manager operations."
+const (
+	Use        = "ops-manager"
+	opsManager = "Ops Manager operations."
+)
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "ops-manager",
+		Use:     Use,
 		Aliases: []string{"om"},
 		Short:   opsManager,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-81627

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Default timeouts were too long for users using ops manager with no access to Atlas and just doing `mongocli --version` could take a long time

I'm handling this in two ways, not longer use of default timeouts and also lowering some of the ones we had. and we'll no longer include the Atlas branch if we don't need to, saving the call completely 
