### PR TITLE
CLOUDP-81757: Use correct separator for dbuser scopes

### DIFF
--- a/e2e/atlas/dbusers_test.go
+++ b/e2e/atlas/dbusers_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	roleReadWrite        = "readWrite"
-	scopeClusterDataLake = "Cluster0,Cluster1@CLUSTER"
+	scopeClusterDataLake = "Cluster0,Cluster1:CLUSTER"
 	clusterName0         = "Cluster0"
 	clusterName1         = "Cluster1"
 	clusterType          = "CLUSTER"

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -174,7 +174,7 @@ func CreateBuilder() *cobra.Command {
   $ mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
 
   Create user with multiple scopes 
-  $ mongocli atlas dbuser create --username <username> --role clusterMonitor --scope clusterName@CLUSTER,DataLakeName@DATA_LAKE --projectId <projectId>
+  $ mongocli atlas dbuser create --username <username> --role clusterMonitor --scope clusterName:CLUSTER,DataLakeName:DATA_LAKE --projectId <projectId>
 `,
 		Args:      cobra.OnlyValidArgs,
 		ValidArgs: []string{"atlasAdmin", "readWriteAnyDatabase", "readAnyDatabase", "clusterMonitor", "backup", "dbAdminAnyDatabase", "enableSharding"},

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -79,7 +79,7 @@ func UpdateBuilder() *cobra.Command {
   $ mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
   Update scopes for a user
-  $ mongocli atlas dbuser update <username> --scope resourceName@resourceType --projectId <projectId>`,
+  $ mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`,
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/convert/database_user.go
+++ b/internal/convert/database_user.go
@@ -25,6 +25,7 @@ const (
 	AdminDB             = "admin"
 	ExternalAuthDB      = "$external"
 	roleSep             = "@"
+	scopeSep            = ":"
 	defaultUserDatabase = "admin"
 	defaultResourceType = "CLUSTER"
 )
@@ -74,7 +75,7 @@ func BuildOMRoles(r []string) []*opsmngr.Role {
 func BuildAtlasScopes(r []string) []atlas.Scope {
 	scopes := make([]atlas.Scope, len(r))
 	for i, scopeP := range r {
-		scope := strings.Split(scopeP, roleSep)
+		scope := strings.Split(scopeP, scopeSep)
 		resourceType := defaultResourceType
 		if len(scope) > 1 {
 			resourceType = scope[1]

--- a/internal/convert/database_user_test.go
+++ b/internal/convert/database_user_test.go
@@ -32,7 +32,8 @@ func TestBuildAtlasRoles(t *testing.T) {
 
 	tests := []test{
 		{
-			input: []string{"admin"}, want: []mongodbatlas.Role{
+			input: []string{"admin"},
+			want: []mongodbatlas.Role{
 				{
 					RoleName:     "admin",
 					DatabaseName: "admin",
@@ -40,7 +41,8 @@ func TestBuildAtlasRoles(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"admin@test"}, want: []mongodbatlas.Role{
+			input: []string{"admin@test"},
+			want: []mongodbatlas.Role{
 				{
 					RoleName:     "admin",
 					DatabaseName: "test",
@@ -48,7 +50,8 @@ func TestBuildAtlasRoles(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"admin@test", "something"}, want: []mongodbatlas.Role{
+			input: []string{"admin@test", "something"},
+			want: []mongodbatlas.Role{
 				{
 					RoleName:     "admin",
 					DatabaseName: "test",
@@ -62,10 +65,15 @@ func TestBuildAtlasRoles(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := BuildAtlasRoles(tc.input)
-		if err := deep.Equal(tc.want, got); err != nil {
-			t.Fatalf("expected: %v, got: %v", tc.want, got)
-		}
+		input := tc.input
+		want := tc.want
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			got := BuildAtlasRoles(input)
+			if err := deep.Equal(want, got); err != nil {
+				t.Fatalf("expected: %v, got: %v", want, got)
+			}
+		})
 	}
 }
 
@@ -77,7 +85,8 @@ func TestBuildOMRoles(t *testing.T) {
 
 	tests := []test{
 		{
-			input: []string{"admin"}, want: []*opsmngr.Role{
+			input: []string{"admin"},
+			want: []*opsmngr.Role{
 				{
 					Role:     "admin",
 					Database: "admin",
@@ -85,7 +94,8 @@ func TestBuildOMRoles(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"admin@test"}, want: []*opsmngr.Role{
+			input: []string{"admin@test"},
+			want: []*opsmngr.Role{
 				{
 					Role:     "admin",
 					Database: "test",
@@ -93,7 +103,8 @@ func TestBuildOMRoles(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"admin@test", "something"}, want: []*opsmngr.Role{
+			input: []string{"admin@test", "something"},
+			want: []*opsmngr.Role{
 				{
 					Role:     "admin",
 					Database: "test",
@@ -107,22 +118,30 @@ func TestBuildOMRoles(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := BuildOMRoles(tc.input)
-		if err := deep.Equal(tc.want, got); err != nil {
-			t.Fatalf("expected: %v, got: %v", tc.want, got)
-		}
+		input := tc.input
+		want := tc.want
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			got := BuildOMRoles(input)
+			if err := deep.Equal(want, got); err != nil {
+				t.Fatalf("expected: %v, got: %v", want, got)
+			}
+		})
 	}
 }
 
-func TestBuildScope(t *testing.T) {
+func TestBuildAtlasScopes(t *testing.T) {
 	type test struct {
+		name  string
 		input []string
 		want  []mongodbatlas.Scope
 	}
 
 	tests := []test{
 		{
-			input: []string{"clusterName"}, want: []mongodbatlas.Scope{
+			name:  "default to cluster",
+			input: []string{"clusterName"},
+			want: []mongodbatlas.Scope{
 				{
 					Name: "clusterName",
 					Type: "CLUSTER",
@@ -130,7 +149,9 @@ func TestBuildScope(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"clusterName@CLUSTER"}, want: []mongodbatlas.Scope{
+			name:  "with cluster type",
+			input: []string{"clusterName:CLUSTER"},
+			want: []mongodbatlas.Scope{
 				{
 					Name: "clusterName",
 					Type: "CLUSTER",
@@ -138,7 +159,9 @@ func TestBuildScope(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"clusterName", "name@DATA_LAKE"}, want: []mongodbatlas.Scope{
+			name:  "default to cluster and a DATA_LAKE",
+			input: []string{"clusterName", "name:DATA_LAKE"},
+			want: []mongodbatlas.Scope{
 				{
 					Name: "clusterName",
 					Type: "CLUSTER",
@@ -150,7 +173,9 @@ func TestBuildScope(t *testing.T) {
 			},
 		},
 		{
-			input: []string{"name@DATA_LAKE"}, want: []mongodbatlas.Scope{
+			name:  "data lake",
+			input: []string{"name:DATA_LAKE"},
+			want: []mongodbatlas.Scope{
 				{
 					Name: "name",
 					Type: "DATA_LAKE",
@@ -160,9 +185,15 @@ func TestBuildScope(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := BuildAtlasScopes(tc.input)
-		if err := deep.Equal(tc.want, got); err != nil {
-			t.Fatalf("expected: %v, got: %v", tc.want, got)
-		}
+		input := tc.input
+		want := tc.want
+		name := tc.name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildAtlasScopes(input)
+			if err := deep.Equal(want, got); err != nil {
+				t.Fatalf("expected: %v, got: %v", want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-81757

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This was discussed in the spec but it looks like we missed it on the review 