### PR TITLE
tests: pin the cache action as 2.1.4 introduced a bug

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: ${{ matrix.golang }}
       - name: Cache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.golang }}-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
See: https://github.com/actions/cache/issues/527
