### PR TITLE
CLOUDP-83534: mongocli atlas privateEndpoint(s)|privateendpoint(s)aws |azure interface(s) delete privateEndpointId doesn't work as expected

### DIFF
--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -39,7 +39,7 @@ func (opts *CreateOpts) initStore() error {
 	return err
 }
 
-var createTemplate = "Interface endpoint '{{.ID}}' created.\n"
+var createTemplate = "Interface endpoint '{{.InterfaceEndpointID}}' created.\n"
 
 func (opts *CreateOpts) Run() error {
 	r, err := opts.store.CreateInterfaceEndpoint(opts.ConfigProjectID(), provider, opts.interfaceEndpointID, opts.newInterfaceEndpointConnection())

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
@@ -41,13 +41,13 @@ func (opts *DeleteOpts) Run() error {
 	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointServiceID)
 }
 
-// mongocli atlas privateEndpoint(s) aws interface(s) delete <atlasPrivateEndpointId> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) aws interface(s) delete <endpointId> [--endpointServiceID endpointServiceID][--projectId projectId]
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
 		DeleteOpts: cli.NewDeleteOpts("Interface endpoint '%s' deleted\n", "Interface endpoint not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:     "delete <atlasPrivateEndpointId>",
+		Use:     "delete <endpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a specific AWS private endpoint interface and the related endpoint service for your project.",
 		Args:    require.ExactArgs(1),
@@ -64,7 +64,7 @@ func DeleteBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
-	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.EndpointServiceID, "", usage.EndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
@@ -27,8 +27,8 @@ import (
 type DeleteOpts struct {
 	cli.GlobalOpts
 	*cli.DeleteOpts
-	privateEndpointID string
-	store             store.InterfaceEndpointDeleter
+	privateEndpointServiceID string
+	store                    store.InterfaceEndpointDeleter
 }
 
 func (opts *DeleteOpts) initStore() error {
@@ -38,10 +38,10 @@ func (opts *DeleteOpts) initStore() error {
 }
 
 func (opts *DeleteOpts) Run() error {
-	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointID)
+	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointServiceID)
 }
 
-// mongocli atlas privateEndpoint(s) aws interface(s) delete <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) aws interface(s) delete <atlasPrivateEndpointId> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
 		DeleteOpts: cli.NewDeleteOpts("Interface endpoint '%s' deleted\n", "Interface endpoint not deleted"),
@@ -49,7 +49,7 @@ func DeleteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <atlasPrivateEndpointId>",
 		Aliases: []string{"rm"},
-		Short:   "Delete a specific AWS private endpoint interface for your project.",
+		Short:   "Delete a specific AWS private endpoint interface and the related endpoint service for your project.",
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore)
@@ -64,7 +64,7 @@ func DeleteBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
-	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
@@ -55,6 +55,6 @@ func TestDeleteBuilder(t *testing.T) {
 		t,
 		DeleteBuilder(),
 		0,
-		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointServiceID},
+		[]string{flag.Force, flag.ProjectID, flag.EndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
@@ -42,7 +42,7 @@ func TestDelete_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		DeleteInterfaceEndpoint(deleteOpts.ProjectID, provider, deleteOpts.privateEndpointID, deleteOpts.Entry).
+		DeleteInterfaceEndpoint(deleteOpts.ProjectID, provider, deleteOpts.privateEndpointServiceID, deleteOpts.Entry).
 		Return(nil).
 		Times(1)
 
@@ -55,6 +55,6 @@ func TestDeleteBuilder(t *testing.T) {
 		t,
 		DeleteBuilder(),
 		0,
-		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointID},
+		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -52,11 +52,11 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas privateEndpoint(s) aws interface(s) describe <privateEndpointID> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) aws interface(s) describe <endpointId> [--endpointServiceID endpointServiceID][--projectId projectId]
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <privateEndpointID>",
+		Use:     "describe <endpointId>",
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific AWS private endpoint interface for your project.",
@@ -72,12 +72,12 @@ func DescribeBuilder() *cobra.Command {
 			return opts.Run()
 		},
 	}
-	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.EndpointServiceID, "", usage.EndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	_ = cmd.MarkFlagRequired(flag.PrivateEndpointServiceID)
+	_ = cmd.MarkFlagRequired(flag.EndpointServiceID)
 
 	return cmd
 }

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -27,9 +27,9 @@ import (
 type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	id                string
-	privateEndpointID string
-	store             store.InterfaceEndpointDescriber
+	privateEndpointServiceID string
+	privateEndpointID        string
+	store                    store.InterfaceEndpointDescriber
 }
 
 func (opts *DescribeOpts) init() error {
@@ -43,7 +43,7 @@ var describeTemplate = `ID	STATUS	ERROR
 `
 
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.InterfaceEndpoint(opts.ConfigProjectID(), provider, opts.id, opts.privateEndpointID)
+	r, err := opts.store.InterfaceEndpoint(opts.ConfigProjectID(), provider, opts.privateEndpointServiceID, opts.privateEndpointID)
 
 	if err != nil {
 		return err
@@ -52,16 +52,16 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas privateEndpoint(s) aws interface(s) describe <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) aws interface(s) describe <privateEndpointID> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <atlasPrivateEndpointId>",
+		Use:     "describe <privateEndpointID>",
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific AWS private endpoint interface for your project.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.id = args[0]
+			opts.privateEndpointID = args[0]
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.init,
@@ -72,12 +72,12 @@ func DescribeBuilder() *cobra.Command {
 			return opts.Run()
 		},
 	}
-	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	_ = cmd.MarkFlagRequired(flag.PrivateEndpointID)
+	_ = cmd.MarkFlagRequired(flag.PrivateEndpointServiceID)
 
 	return cmd
 }

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -33,16 +33,16 @@ func TestDescribeOpts_Run(t *testing.T) {
 	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
-		store:             mockStore,
-		privateEndpointID: "privateEndpointID",
-		id:                "id",
+		store:                    mockStore,
+		privateEndpointID:        "privateEndpointID",
+		privateEndpointServiceID: "id",
 	}
 
 	expected := &mongodbatlas.InterfaceEndpointConnection{}
 
 	mockStore.
 		EXPECT().
-		InterfaceEndpoint(opts.ProjectID, provider, opts.id, opts.privateEndpointID).
+		InterfaceEndpoint(opts.ProjectID, provider, opts.privateEndpointServiceID, opts.privateEndpointID).
 		Return(expected, nil).
 		Times(1)
 
@@ -55,6 +55,6 @@ func TestDescribeBuilder(t *testing.T) {
 		t,
 		DescribeBuilder(),
 		0,
-		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointID},
+		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -55,6 +55,6 @@ func TestDescribeBuilder(t *testing.T) {
 		t,
 		DescribeBuilder(),
 		0,
-		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointServiceID},
+		[]string{flag.Output, flag.ProjectID, flag.EndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -40,7 +40,7 @@ func (opts *CreateOpts) initStore() error {
 	return err
 }
 
-var createTemplate = "Interface endpoint '{{.ID}}' created.\n"
+var createTemplate = "Interface endpoint '{{.PrivateEndpointResourceID}}' created.\n"
 
 func (opts *CreateOpts) Run() error {
 	r, err := opts.store.CreateInterfaceEndpoint(opts.ConfigProjectID(), provider, opts.interfaceEndpointID, opts.newInterfaceEndpointConnection())

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
@@ -27,8 +27,8 @@ import (
 type DeleteOpts struct {
 	cli.GlobalOpts
 	*cli.DeleteOpts
-	privateEndpointID string
-	store             store.InterfaceEndpointDeleter
+	privateEndpointServiceID string
+	store                    store.InterfaceEndpointDeleter
 }
 
 func (opts *DeleteOpts) initStore() error {
@@ -38,18 +38,18 @@ func (opts *DeleteOpts) initStore() error {
 }
 
 func (opts *DeleteOpts) Run() error {
-	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointID)
+	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointServiceID)
 }
 
-// mongocli atlas privateEndpoint(s) azure interface(s) delete <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) azure interface(s) delete <privateEndpointId> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
 		DeleteOpts: cli.NewDeleteOpts("Interface endpoint '%s' deleted\n", "Interface endpoint not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:     "delete <atlasPrivateEndpointId>",
+		Use:     "delete <privateEndpointId>",
 		Aliases: []string{"rm"},
-		Short:   "Delete a specific Azure private endpoint interface for your project.",
+		Short:   "Delete a specific Azure private endpoint interface and related service for your project.",
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore)
@@ -64,7 +64,7 @@ func DeleteBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
-	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
@@ -41,13 +41,13 @@ func (opts *DeleteOpts) Run() error {
 	return opts.Delete(opts.store.DeleteInterfaceEndpoint, opts.ConfigProjectID(), provider, opts.privateEndpointServiceID)
 }
 
-// mongocli atlas privateEndpoint(s) azure interface(s) delete <privateEndpointId> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) azure interface(s) delete <endpointId> [--endpointServiceID endpointServiceID][--projectId projectId]
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
 		DeleteOpts: cli.NewDeleteOpts("Interface endpoint '%s' deleted\n", "Interface endpoint not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:     "delete <privateEndpointId>",
+		Use:     "delete <endpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a specific Azure private endpoint interface and related service for your project.",
 		Args:    require.ExactArgs(1),
@@ -64,7 +64,7 @@ func DeleteBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
-	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.EndpointServiceID, "", usage.EndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
@@ -55,6 +55,6 @@ func TestDeleteBuilder(t *testing.T) {
 		t,
 		DeleteBuilder(),
 		0,
-		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointServiceID},
+		[]string{flag.Force, flag.ProjectID, flag.EndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
@@ -42,7 +42,7 @@ func TestDelete_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		DeleteInterfaceEndpoint(deleteOpts.ProjectID, provider, deleteOpts.privateEndpointID, deleteOpts.Entry).
+		DeleteInterfaceEndpoint(deleteOpts.ProjectID, provider, deleteOpts.privateEndpointServiceID, deleteOpts.Entry).
 		Return(nil).
 		Times(1)
 
@@ -55,6 +55,6 @@ func TestDeleteBuilder(t *testing.T) {
 		t,
 		DeleteBuilder(),
 		0,
-		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointID},
+		[]string{flag.Force, flag.ProjectID, flag.PrivateEndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -52,11 +52,11 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas privateEndpoint(s) azure interface(s) describe <privateEndpointID> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) azure interface(s) describe <endpointId> [--endpointServiceID endpointServiceID][--projectId projectId]
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <privateEndpointID>",
+		Use:     "describe <endpointId>",
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific Azure private endpoint interface for your project.",
@@ -72,12 +72,12 @@ func DescribeBuilder() *cobra.Command {
 			return opts.Run()
 		},
 	}
-	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.EndpointServiceID, "", usage.EndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	_ = cmd.MarkFlagRequired(flag.PrivateEndpointServiceID)
+	_ = cmd.MarkFlagRequired(flag.EndpointServiceID)
 
 	return cmd
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -27,9 +27,9 @@ import (
 type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	id                string
-	privateEndpointID string
-	store             store.InterfaceEndpointDescriber
+	privateEndpointID        string
+	privateEndpointServiceID string
+	store                    store.InterfaceEndpointDescriber
 }
 
 func (opts *DescribeOpts) init() error {
@@ -43,7 +43,7 @@ var describeTemplate = `ID	IP ADDRESS	STATUS	ERROR
 `
 
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.InterfaceEndpoint(opts.ConfigProjectID(), provider, opts.id, opts.privateEndpointID)
+	r, err := opts.store.InterfaceEndpoint(opts.ConfigProjectID(), provider, opts.privateEndpointServiceID, opts.privateEndpointID)
 
 	if err != nil {
 		return err
@@ -52,16 +52,16 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas privateEndpoint(s) azure interface(s) describe <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID][--projectId projectId]
+// mongocli atlas privateEndpoint(s) azure interface(s) describe <privateEndpointID> [--privateEndpointServiceID privateEndpointServiceID][--projectId projectId]
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <atlasPrivateEndpointId>",
+		Use:     "describe <privateEndpointID>",
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific Azure private endpoint interface for your project.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.id = args[0]
+			opts.privateEndpointID = args[0]
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.init,
@@ -72,12 +72,12 @@ func DescribeBuilder() *cobra.Command {
 			return opts.Run()
 		},
 	}
-	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
+	cmd.Flags().StringVar(&opts.privateEndpointServiceID, flag.PrivateEndpointServiceID, "", usage.PrivateEndpointServiceID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	_ = cmd.MarkFlagRequired(flag.PrivateEndpointID)
+	_ = cmd.MarkFlagRequired(flag.PrivateEndpointServiceID)
 
 	return cmd
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -33,16 +33,16 @@ func TestDescribeOpts_Run(t *testing.T) {
 	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
-		store:             mockStore,
-		privateEndpointID: "privateEndpointID",
-		id:                "id",
+		store:                    mockStore,
+		privateEndpointServiceID: "privateEndpointID",
+		privateEndpointID:        "id",
 	}
 
 	expected := &mongodbatlas.InterfaceEndpointConnection{}
 
 	mockStore.
 		EXPECT().
-		InterfaceEndpoint(opts.ProjectID, provider, opts.id, opts.privateEndpointID).
+		InterfaceEndpoint(opts.ProjectID, provider, opts.privateEndpointServiceID, opts.privateEndpointID).
 		Return(expected, nil).
 		Times(1)
 
@@ -55,6 +55,6 @@ func TestDescribeBuilder(t *testing.T) {
 		t,
 		DescribeBuilder(),
 		0,
-		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointID},
+		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointServiceID},
 	)
 }

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -55,6 +55,6 @@ func TestDescribeBuilder(t *testing.T) {
 		t,
 		DescribeBuilder(),
 		0,
-		[]string{flag.Output, flag.ProjectID, flag.PrivateEndpointServiceID},
+		[]string{flag.Output, flag.ProjectID, flag.EndpointServiceID},
 	)
 }

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -193,7 +193,7 @@ const (
 	IP                              = "ip"                              // IP flag
 	CIDR                            = "cidr"                            // CIDR flag
 	PrivateEndpointID               = "privateEndpointId"               // PrivateEndpointID flag
-	PrivateEndpointServiceID        = "privateEndpointServiceId"        // privateEndpointServiceId flag
+	EndpointServiceID               = "endpointServiceId"               // EndpointServiceId flag
 	PrivateEndpointIPAddress        = "privateEndpointIpAddress"        // PrivateEndpointIPAddress flag
 	Retention                       = "retention"                       // Retention flag
 	AtlasCIDRBlock                  = "atlasCidrBlock"                  // AtlasCIDRBlock flag

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -193,6 +193,7 @@ const (
 	IP                              = "ip"                              // IP flag
 	CIDR                            = "cidr"                            // CIDR flag
 	PrivateEndpointID               = "privateEndpointId"               // PrivateEndpointID flag
+	PrivateEndpointServiceID        = "privateEndpointServiceId"        // privateEndpointServiceId flag
 	PrivateEndpointIPAddress        = "privateEndpointIpAddress"        // PrivateEndpointIPAddress flag
 	Retention                       = "retention"                       // Retention flag
 	AtlasCIDRBlock                  = "atlasCidrBlock"                  // AtlasCIDRBlock flag

--- a/internal/store/private_endpoints.go
+++ b/internal/store/private_endpoints.go
@@ -127,7 +127,7 @@ func (s *Store) InterfaceEndpoint(projectID, cloudProvider, endpointServiceID, p
 }
 
 // DeleteInterfaceEndpoint encapsulates the logic to manage different cloud providers
-func (s *Store) DeleteInterfaceEndpoint(projectID, provider, privateEndpointID, endpointServiceID string) error {
+func (s *Store) DeleteInterfaceEndpoint(projectID, provider, endpointServiceID, privateEndpointID string) error {
 	switch s.service {
 	case config.CloudService:
 		_, err := s.client.(*atlas.Client).PrivateEndpoints.DeleteOnePrivateEndpoint(context.Background(), projectID, provider, endpointServiceID, privateEndpointID)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -220,6 +220,7 @@ const (
 	AccessListIPEntry               = "IP address to be allowed for a given API key."
 	AccessListCIDREntry             = "Whitelist entry in CIDR notation to be added for a given API key."
 	PrivateEndpointID               = "Unique identifier of the AWS PrivateLink connection."
+	PrivateEndpointServiceID        = "Unique identifier of the private endpoint service for which you want to retrieve a private endpoint."
 	PrivateEndpointIDAzure          = "Unique identifier of the Azure private endpoint resource."
 	PrivateEndpointIPAddressAzure   = "Private IP address of the private endpoint network interface you created in your Azure VNet."
 	AccountID                       = "Account ID of the owner of the peer VPC."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -220,7 +220,7 @@ const (
 	AccessListIPEntry               = "IP address to be allowed for a given API key."
 	AccessListCIDREntry             = "Whitelist entry in CIDR notation to be added for a given API key."
 	PrivateEndpointID               = "Unique identifier of the AWS PrivateLink connection."
-	PrivateEndpointServiceID        = "Unique identifier of the private endpoint service for which you want to retrieve a private endpoint."
+	EndpointServiceID               = "Unique identifier of the private endpoint service for which you want to retrieve a private endpoint."
 	PrivateEndpointIDAzure          = "Unique identifier of the Azure private endpoint resource."
 	PrivateEndpointIPAddressAzure   = "Private IP address of the private endpoint network interface you created in your Azure VNet."
 	AccountID                       = "Account ID of the owner of the peer VPC."


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-83534


<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

**DELETE** 
Endpoint: [DELETE /groups/{GROUP-ID}/privateEndpoint/{CLOUD-PROVIDER}/endpointService/{ENDPOINT-SERVICE-ID}/endpoint/{ENDPOINT-ID}](https://docs.atlas.mongodb.com/reference/api/private-endpoints-endpoint-delete-one/)
```
./bin/mongocli atlas privateendpoint aws interface delete --help


Delete a specific AWS private endpoint interface and the related endpoint service for your project.

Usage:
  mongocli atlas privateEndpoints aws interfaces delete <atlasPrivateEndpointId> [flags]

Aliases:
  delete, rm

Flags:
      --force                             Don't ask for confirmation.
  -h, --help                              help for delete
      --endpointServiceId string   Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
      --projectId string                  Project ID to use. Overrides configuration file or environment variable settings.
```

```
./bin/mongocli atlas privateendpoint aws interface delete vpce-09261072f5531a201 --endpointServiceId 603e2b7e91355579212e0df2

? Are you sure you want to delete: vpce-09261072f5531a201 Yes
Interface endpoint 'vpce-09261072f5531a201' deleted
```




**GET**
Endpoint: [GET /groups/{GROUP-ID}/privateEndpoint/{CLOUD-PROVIDER}/endpointService/{ENDPOINT-SERVICE-ID}/endpoint/{ENDPOINT-ID}](https://docs.atlas.mongodb.com/reference/api/private-endpoints-endpoint-get-one/)

```
./bin/mongocli atlas privateendpoint aws interface describe --help

Return a specific AWS private endpoint interface for your project.

Usage:
  mongocli atlas privateEndpoints aws interfaces describe <privateEndpointID> [flags]

Aliases:
  describe, get

Flags:
  -h, --help                              help for describe
  -o, --output string                     Output format.
                                          Valid values: json|go-template|go-template-file
      --endpointServiceId string   Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
      --projectId string                  Project ID to use. Overrides configuration file or environment variable settings.

Global Flags:
  -P, --profile string   Profile to use from your configuration file.
```

```
./bin/mongocli atlas privateendpoint aws interface describe vpce-0b24b91f9355f967a --endpointServiceId 603e30ed91355579212e153e

ID                       STATUS      ERROR
vpce-0b24b91f9355f967a   AVAILABLE
```