### PR TITLE
CLOUDP-83921: Offer a suggestion when missing credentials

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -92,7 +92,7 @@ func ObjectID(s string) error {
 func Credentials() error {
 	if config.PrivateAPIKey() == "" || config.PublicAPIKey() == "" {
 		return fmt.Errorf(
-			"missing credentials\n\nStart with:  %s %s",
+			"missing credentials\n\nTo set credentials, run: %s %s",
 			config.ToolName,
 			"config",
 		)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -16,14 +16,12 @@ package validate
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 
-	"github.com/mongodb/mongocli/internal/search"
-
 	"github.com/mongodb/mongocli/internal/config"
+	"github.com/mongodb/mongocli/internal/search"
 )
 
 // toString tries to cast an interface to string
@@ -75,11 +73,8 @@ func OptionalObjectID(val interface{}) error {
 		return nil
 	}
 	s, err := toString(val)
-	if err != nil {
+	if err != nil || s == "" {
 		return err
-	}
-	if s == "" {
-		return nil
 	}
 	return ObjectID(s)
 }
@@ -96,7 +91,11 @@ func ObjectID(s string) error {
 // Credentials validates public and private API keys have been set
 func Credentials() error {
 	if config.PrivateAPIKey() == "" || config.PublicAPIKey() == "" {
-		return errors.New("missing credentials")
+		return fmt.Errorf(
+			"missing credentials\n\nStart with:  %s %s",
+			config.ToolName,
+			"config",
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-83921

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This PR tries to do something similar to how we offer usage on missing args

```bash
mongocli config get
Error: "mongocli config describe" requires 1 argument

Usage:  mongocli config describe <name> [flags]
```

If there are no credentials then we get something like
```bash
mongocli iam projects ls
Error: missing credentials

To set credentials, run: mongocli config
```