### PR TITLE
CLOUDP-85231: No path hacking needed with go1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ export E2E_BINARY
 .PHONY: setup
 setup:  ## Install dev tools
 	@echo "==> Installing dependencies..."
+	go install github.com/google/addlicense@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
 
 .PHONY: link-git-hooks

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,22 @@ export PATH := ./bin:$(PATH)
 export GO111MODULE := on
 export E2E_BINARY
 
-.PHONY: setup
-setup:  ## Install dev tools
-	@echo "==> Installing dependencies..."
+.PHONY: setupgolangcilint
+setupgolangcilint:  ## Install golangci-lint
+	@echo "==> Installing golangci-lint..."
 	go install github.com/google/addlicense@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
+
+.PHONY: deps
+deps:  ## Download go module dependencies
+	@echo "==> Installing go.mod dependencies..."
+	go mod download
+	go mod tidy
+
+.PHONY: setup
+setup: deps setupgolangcilint ## Set up dev env
+	@echo "==> Installing dev tools..."
+	go install github.com/google/addlicense@latest
 
 .PHONY: link-git-hooks
 link-git-hooks: ## Install git hooks

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ export E2E_BINARY
 .PHONY: setupgolangcilint
 setupgolangcilint:  ## Install golangci-lint
 	@echo "==> Installing golangci-lint..."
-	go install github.com/google/addlicense@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
 
 .PHONY: deps

--- a/build/ci/check-licenses.sh
+++ b/build/ci/check-licenses.sh
@@ -20,11 +20,7 @@ set -Eeou pipefail
 export GOPATH="${workdir:?}"
 export PATH="$GOPATH/bin:$PATH"
 
-pushd "${GOPATH}"
-
-go get github.com/google/addlicense
-
-popd
+go install github.com/google/addlicense@latest
 
 find_files() {
   find . -not \( \

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -197,7 +197,7 @@ functions:
       type: setup
       params:
         working_dir: src/github.com/mongodb/mongocli
-        command: make setup
+        command: make setupgolangcilint
   "install gon":
     - command: shell.exec
       type: setup

--- a/build/package/generate-notices.sh
+++ b/build/package/generate-notices.sh
@@ -20,11 +20,7 @@ set -Eeou pipefail
 export GOPATH="${workdir:?}"
 export PATH="$GOPATH/bin:$PATH"
 
-pushd "${GOPATH}"
-
-go get github.com/google/go-licenses
-
-popd
+go install github.com/google/go-licenses@latest
 
 go-licenses save "github.com/mongodb/mongocli/cmd/mongocli" --save_path=third_party_notices
 # For HCL, a dependency of viper, go-license adds the source code with restricted permissions, this is a problem for some linux users


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-85231

## Checklist


- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

With go1.16 we no longer need to be hopping dirs t avoid unintended changes to the go.mod file