### PR TITLE
Fixed acknowledge_test.go

### DIFF
--- a/internal/cli/alerts/acknowledge_test.go
+++ b/internal/cli/alerts/acknowledge_test.go
@@ -87,7 +87,6 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 		opts := tt.opts
 		wantErr := tt.wantErr
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			ackReq := opts.newAcknowledgeRequest()
 			if wantErr {
 				mockStore.


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-#

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->


The failure in `acknowledge_test.go` seem related to `t.Parallel()`.Indeed the mock returns the error even if `wantErr` is false for the test case `forever`

```
ok  	github.com/mongodb/mongocli/internal/cli	0.189s	coverage: 32.3% of statements
&{      <nil>         <nil>   [] <nil> []}
&{      <nil>         <nil>   [] <nil> []}
--- FAIL: TestAcknowledgeOpts_Run (0.00s)
    --- FAIL: TestAcknowledgeOpts_Run/forever (0.00s)
        acknowledge_test.go:106: 
            	Error Trace:	acknowledge_test.go:106
            	Error:      	Received unexpected error:
            	            	fake
            	Test:       	TestAcknowledgeOpts_Run/forever
    --- FAIL: TestAcknowledgeOpts_Run/with_error (0.00s)
        acknowledge_test.go:98: 
            	Error Trace:	acknowledge_test.go:98
            	Error:      	An error is expected but got nil.
            	Test:       	TestAcknowledgeOpts_Run/with_error
&{      <nil>         <nil>   [] <nil> []}
&{[] [] 0}
&{[] [] 0}
&{      <nil>         <nil>   [] <nil> []}
FAIL
```