### PR TITLE
task: refactor how we create stores

### DIFF
--- a/internal/cli/alerts/acknowledge.go
+++ b/internal/cli/alerts/acknowledge.go
@@ -40,7 +40,7 @@ type AcknowledgeOpts struct {
 
 func (opts *AcknowledgeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/describe.go
+++ b/internal/cli/alerts/describe.go
@@ -33,7 +33,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/global_list.go
+++ b/internal/cli/alerts/global_list.go
@@ -34,7 +34,7 @@ type GlobalListOpts struct {
 
 func (opts *GlobalListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -33,7 +33,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/settings/delete.go
+++ b/internal/cli/alerts/settings/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/settings/fields_type.go
+++ b/internal/cli/alerts/settings/fields_type.go
@@ -31,7 +31,7 @@ type FieldsTypeOpts struct {
 
 func (opts *FieldsTypeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/settings/list.go
+++ b/internal/cli/alerts/settings/list.go
@@ -33,7 +33,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/settings/update.go
+++ b/internal/cli/alerts/settings/update.go
@@ -34,7 +34,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/alerts/unacknowledge.go
+++ b/internal/cli/alerts/unacknowledge.go
@@ -35,7 +35,7 @@ type UnacknowledgeOpts struct {
 
 func (opts *UnacknowledgeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -44,7 +44,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/accesslists/describe.go
+++ b/internal/cli/atlas/accesslists/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/accesslists/list.go
+++ b/internal/cli/atlas/accesslists/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/restores_list.go
+++ b/internal/cli/atlas/backup/restores_list.go
@@ -34,7 +34,7 @@ type RestoresListOpts struct {
 
 func (opts *RestoresListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/restores_start.go
+++ b/internal/cli/atlas/backup/restores_start.go
@@ -50,7 +50,7 @@ type RestoresStartOpts struct {
 
 func (opts *RestoresStartOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/snapshots/delete.go
+++ b/internal/cli/atlas/backup/snapshots/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/snapshots/describe.go
+++ b/internal/cli/atlas/backup/snapshots/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/snapshots/list.go
+++ b/internal/cli/atlas/backup/snapshots/list.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -34,7 +34,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
@@ -37,7 +37,7 @@ type AuthorizeOpts struct {
 
 func (opts *AuthorizeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
@@ -40,7 +40,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -40,7 +40,7 @@ type DeauthorizeOpts struct {
 
 func (opts *DeauthorizeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/cloudproviders/accessroles/list.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list.go
@@ -32,7 +32,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/connectionstring/describe.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe.go
@@ -34,7 +34,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -60,7 +60,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 
@@ -261,7 +261,7 @@ func DefaultMongoDBMajorVersion() (string, error) {
 	if defaultMongoDBMajorVersion != "" {
 		return defaultMongoDBMajorVersion, nil
 	}
-	s, err := store.NewPrivateUnauth(config.Default())
+	s, err := store.New(store.PrivateUnauthenticatedPreset(config.Default()))
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/describe.go
+++ b/internal/cli/atlas/clusters/describe.go
@@ -33,7 +33,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/indexes/create.go
+++ b/internal/cli/atlas/clusters/indexes/create.go
@@ -41,7 +41,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/list.go
+++ b/internal/cli/atlas/clusters/list.go
@@ -33,7 +33,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/loadSampleData.go
+++ b/internal/cli/atlas/clusters/loadSampleData.go
@@ -33,7 +33,7 @@ type LoadSampleDataOpts struct {
 
 func (opts *LoadSampleDataOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/pause.go
+++ b/internal/cli/atlas/clusters/pause.go
@@ -33,7 +33,7 @@ type PauseOpts struct {
 
 func (opts *PauseOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/start.go
+++ b/internal/cli/atlas/clusters/start.go
@@ -33,7 +33,7 @@ type StartOpts struct {
 
 func (opts *StartOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -41,7 +41,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -33,7 +33,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -41,7 +41,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdbroles/delete.go
+++ b/internal/cli/atlas/customdbroles/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdbroles/describe.go
+++ b/internal/cli/atlas/customdbroles/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdbroles/list.go
+++ b/internal/cli/atlas/customdbroles/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdbroles/update.go
+++ b/internal/cli/atlas/customdbroles/update.go
@@ -42,7 +42,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdns/aws/describe.go
+++ b/internal/cli/atlas/customdns/aws/describe.go
@@ -35,7 +35,7 @@ const describeTemplate = `ENABLED
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdns/aws/disable.go
+++ b/internal/cli/atlas/customdns/aws/disable.go
@@ -33,7 +33,7 @@ var disableTemplate = "DNS configuration disabled.\n"
 
 func (opts *DisableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/customdns/aws/enable.go
+++ b/internal/cli/atlas/customdns/aws/enable.go
@@ -33,7 +33,7 @@ var enableTemplate = "DNS configuration enabled.\n"
 
 func (opts *EnableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -33,7 +33,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -32,7 +32,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -41,7 +41,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/certs/create.go
+++ b/internal/cli/atlas/dbusers/certs/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/certs/list.go
+++ b/internal/cli/atlas/dbusers/certs/list.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -77,7 +77,7 @@ func (opts *CreateOpts) isExternal() bool {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/delete.go
+++ b/internal/cli/atlas/dbusers/delete.go
@@ -34,7 +34,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/describe.go
+++ b/internal/cli/atlas/dbusers/describe.go
@@ -39,7 +39,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/list.go
+++ b/internal/cli/atlas/dbusers/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -40,7 +40,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/datadog.go
+++ b/internal/cli/atlas/integrations/create/datadog.go
@@ -37,7 +37,7 @@ type DatadogOpts struct {
 
 func (opts *DatadogOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/flowdock.go
+++ b/internal/cli/atlas/integrations/create/flowdock.go
@@ -38,7 +38,7 @@ type FlowdockOpts struct {
 
 func (opts *FlowdockOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/new_relic.go
+++ b/internal/cli/atlas/integrations/create/new_relic.go
@@ -39,7 +39,7 @@ type NewRelicOpts struct {
 
 func (opts *NewRelicOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/ops_genie.go
+++ b/internal/cli/atlas/integrations/create/ops_genie.go
@@ -37,7 +37,7 @@ type OpsGenieOpts struct {
 
 func (opts *OpsGenieOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/pager_duty.go
+++ b/internal/cli/atlas/integrations/create/pager_duty.go
@@ -36,7 +36,7 @@ type PagerDutyOpts struct {
 
 func (opts *PagerDutyOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/victor_ops.go
+++ b/internal/cli/atlas/integrations/create/victor_ops.go
@@ -37,7 +37,7 @@ type VictorOpsOpts struct {
 
 func (opts *VictorOpsOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -37,7 +37,7 @@ type WebhookOpts struct {
 
 func (opts *WebhookOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/delete.go
+++ b/internal/cli/atlas/integrations/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/describe.go
+++ b/internal/cli/atlas/integrations/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/integrations/list.go
+++ b/internal/cli/atlas/integrations/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/logs/download.go
+++ b/internal/cli/atlas/logs/download.go
@@ -44,7 +44,7 @@ var downloadMessage = "Download of %s completed.\n"
 
 func (opts *DownloadOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/maintenance/clear.go
+++ b/internal/cli/atlas/maintenance/clear.go
@@ -34,7 +34,7 @@ type ClearOpts struct {
 
 func (opts *ClearOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/maintenance/defer.go
+++ b/internal/cli/atlas/maintenance/defer.go
@@ -31,7 +31,7 @@ type DeferOpts struct {
 
 func (opts *DeferOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/maintenance/describe.go
+++ b/internal/cli/atlas/maintenance/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/maintenance/update.go
+++ b/internal/cli/atlas/maintenance/update.go
@@ -35,7 +35,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/metrics/databases_describe.go
+++ b/internal/cli/atlas/metrics/databases_describe.go
@@ -36,7 +36,7 @@ type DatabasesDescribeOpts struct {
 
 func (opts *DatabasesDescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/metrics/databases_list.go
+++ b/internal/cli/atlas/metrics/databases_list.go
@@ -35,7 +35,7 @@ type DatabasesListsOpts struct {
 
 func (opts *DatabasesListsOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/metrics/disks_describe.go
+++ b/internal/cli/atlas/metrics/disks_describe.go
@@ -36,7 +36,7 @@ type DisksDescribeOpts struct {
 
 func (opts *DisksDescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/metrics/disks_list.go
+++ b/internal/cli/atlas/metrics/disks_list.go
@@ -35,7 +35,7 @@ type DisksListsOpts struct {
 
 func (opts *DisksListsOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/metrics/processes.go
+++ b/internal/cli/atlas/metrics/processes.go
@@ -35,7 +35,7 @@ type ProcessOpts struct {
 
 func (opts *ProcessOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/containers/delete.go
+++ b/internal/cli/atlas/networking/containers/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/containers/list.go
+++ b/internal/cli/atlas/networking/containers/list.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/create/aws.go
+++ b/internal/cli/atlas/networking/peering/create/aws.go
@@ -40,7 +40,7 @@ type AWSOpts struct {
 
 func (opts *AWSOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -41,7 +41,7 @@ type AzureOpts struct {
 
 func (opts *AzureOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/create/gcp.go
+++ b/internal/cli/atlas/networking/peering/create/gcp.go
@@ -37,7 +37,7 @@ type GCPOpts struct {
 
 func (opts *GCPOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/delete.go
+++ b/internal/cli/atlas/networking/peering/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/list.go
+++ b/internal/cli/atlas/networking/peering/list.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -33,7 +33,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/create.go
+++ b/internal/cli/atlas/onlinearchive/create.go
@@ -42,7 +42,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/delete.go
+++ b/internal/cli/atlas/onlinearchive/delete.go
@@ -34,7 +34,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/describe.go
+++ b/internal/cli/atlas/onlinearchive/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/list.go
+++ b/internal/cli/atlas/onlinearchive/list.go
@@ -33,7 +33,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/pause.go
+++ b/internal/cli/atlas/onlinearchive/pause.go
@@ -35,7 +35,7 @@ type PauseOpts struct {
 
 func (opts *PauseOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/start.go
+++ b/internal/cli/atlas/onlinearchive/start.go
@@ -35,7 +35,7 @@ type StartOpts struct {
 
 func (opts *StartOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/onlinearchive/update.go
+++ b/internal/cli/atlas/onlinearchive/update.go
@@ -36,7 +36,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -35,7 +35,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -34,7 +34,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/aws/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -33,7 +33,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -34,7 +34,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/list.go
+++ b/internal/cli/atlas/privateendpoints/azure/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -33,7 +33,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/create.go
+++ b/internal/cli/atlas/privateendpoints/create.go
@@ -35,7 +35,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/delete.go
+++ b/internal/cli/atlas/privateendpoints/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/describe.go
+++ b/internal/cli/atlas/privateendpoints/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe.go
@@ -34,7 +34,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/list.go
+++ b/internal/cli/atlas/privateendpoints/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
@@ -33,7 +33,7 @@ var disableTemplate = "Regionalized private endpoint setting disabled.\n"
 
 func (opts *DisableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
@@ -33,7 +33,7 @@ var enableTemplate = "Regionalized private endpoint setting enabled.\n"
 
 func (opts *EnableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -34,7 +34,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/processes/processes_list.go
+++ b/internal/cli/atlas/processes/processes_list.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -104,7 +104,7 @@ type Opts struct {
 
 func (opts *Opts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/search/create.go
+++ b/internal/cli/atlas/search/create.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/search/delete.go
+++ b/internal/cli/atlas/search/delete.go
@@ -34,7 +34,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/search/update.go
+++ b/internal/cli/atlas/search/update.go
@@ -35,7 +35,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -37,7 +37,7 @@ type SaveOpts struct {
 
 func (opts *SaveOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/customercerts/describe.go
+++ b/internal/cli/atlas/security/customercerts/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/customercerts/disable.go
+++ b/internal/cli/atlas/security/customercerts/disable.go
@@ -35,7 +35,7 @@ type DisableOpts struct {
 
 func (opts *DisableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/delete.go
+++ b/internal/cli/atlas/security/ldap/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/get.go
+++ b/internal/cli/atlas/security/ldap/get.go
@@ -35,7 +35,7 @@ type GetOpts struct {
 
 func (opts *GetOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -40,7 +40,7 @@ type SaveOpts struct {
 
 func (opts *SaveOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/status.go
+++ b/internal/cli/atlas/security/ldap/status.go
@@ -33,7 +33,7 @@ type StatusOpts struct {
 
 func (opts *StatusOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/verify.go
+++ b/internal/cli/atlas/security/ldap/verify.go
@@ -38,7 +38,7 @@ type VerifyOpts struct {
 
 func (opts *VerifyOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -33,7 +33,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -51,7 +51,7 @@ type configOpts struct {
 
 func (opts *configOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/events/list.go
+++ b/internal/cli/events/list.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalaccesslists/create.go
+++ b/internal/cli/iam/globalaccesslists/create.go
@@ -35,7 +35,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalaccesslists/delete.go
+++ b/internal/cli/iam/globalaccesslists/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalaccesslists/describe.go
+++ b/internal/cli/iam/globalaccesslists/describe.go
@@ -31,7 +31,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalaccesslists/list.go
+++ b/internal/cli/iam/globalaccesslists/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalapikeys/create.go
+++ b/internal/cli/iam/globalapikeys/create.go
@@ -38,7 +38,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalapikeys/delete.go
+++ b/internal/cli/iam/globalapikeys/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalapikeys/describe.go
+++ b/internal/cli/iam/globalapikeys/describe.go
@@ -31,7 +31,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalapikeys/list.go
+++ b/internal/cli/iam/globalapikeys/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/globalapikeys/update.go
+++ b/internal/cli/iam/globalapikeys/update.go
@@ -34,7 +34,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create.go
@@ -39,7 +39,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/list.go
@@ -38,7 +38,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/create.go
+++ b/internal/cli/iam/organizations/apikeys/create.go
@@ -40,7 +40,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/delete.go
+++ b/internal/cli/iam/organizations/apikeys/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/describe.go
+++ b/internal/cli/iam/organizations/apikeys/describe.go
@@ -32,7 +32,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/list.go
+++ b/internal/cli/iam/organizations/apikeys/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/apikeys/update.go
+++ b/internal/cli/iam/organizations/apikeys/update.go
@@ -35,7 +35,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/create.go
+++ b/internal/cli/iam/organizations/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/delete.go
+++ b/internal/cli/iam/organizations/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/list.go
+++ b/internal/cli/iam/organizations/list.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/organizations/users/list.go
+++ b/internal/cli/iam/organizations/users/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/apikeys/assign.go
+++ b/internal/cli/iam/projects/apikeys/assign.go
@@ -35,7 +35,7 @@ type AssignOpts struct {
 
 func (opts *AssignOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -40,7 +40,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/apikeys/delete.go
+++ b/internal/cli/iam/projects/apikeys/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/apikeys/list.go
+++ b/internal/cli/iam/projects/apikeys/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/create.go
+++ b/internal/cli/iam/projects/create.go
@@ -39,7 +39,7 @@ func (opts *CreateOpts) init() error {
 	}
 
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/delete.go
+++ b/internal/cli/iam/projects/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/describe.go
+++ b/internal/cli/iam/projects/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/list.go
+++ b/internal/cli/iam/projects/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/teams/add.go
+++ b/internal/cli/iam/projects/teams/add.go
@@ -37,7 +37,7 @@ type AddOpts struct {
 
 func (opts *AddOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/teams/delete.go
+++ b/internal/cli/iam/projects/teams/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/teams/list.go
+++ b/internal/cli/iam/projects/teams/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/teams/update.go
+++ b/internal/cli/iam/projects/teams/update.go
@@ -37,7 +37,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/users/delete.go
+++ b/internal/cli/iam/projects/users/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/projects/users/list.go
+++ b/internal/cli/iam/projects/users/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/create.go
+++ b/internal/cli/iam/teams/create.go
@@ -37,7 +37,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/delete.go
+++ b/internal/cli/iam/teams/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -40,7 +40,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/list.go
+++ b/internal/cli/iam/teams/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/users/add.go
+++ b/internal/cli/iam/teams/users/add.go
@@ -36,7 +36,7 @@ type AddOpts struct {
 
 func (opts *AddOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/users/delete.go
+++ b/internal/cli/iam/teams/users/delete.go
@@ -33,7 +33,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/teams/users/list.go
+++ b/internal/cli/iam/teams/users/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/users/delete.go
+++ b/internal/cli/iam/users/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -39,7 +39,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/iam/users/invite.go
+++ b/internal/cli/iam/users/invite.go
@@ -48,7 +48,7 @@ type InviteOpts struct {
 
 func (opts *InviteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/create.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/delete.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/describe.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/list.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/update.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/update.go
@@ -35,7 +35,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/create.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/create.go
@@ -38,7 +38,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/delete.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/describe.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/list.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/update.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/update.go
@@ -39,7 +39,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/oplog/create.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/oplog/delete.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/oplog/describe.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/oplog/list.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/oplog/update.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/update.go
@@ -36,7 +36,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/s3/create.go
+++ b/internal/cli/opsmanager/admin/backup/s3/create.go
@@ -45,7 +45,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/s3/delete.go
+++ b/internal/cli/opsmanager/admin/backup/s3/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/s3/describe.go
+++ b/internal/cli/opsmanager/admin/backup/s3/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/s3/list.go
+++ b/internal/cli/opsmanager/admin/backup/s3/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/s3/update.go
+++ b/internal/cli/opsmanager/admin/backup/s3/update.go
@@ -46,7 +46,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/sync/create.go
+++ b/internal/cli/opsmanager/admin/backup/sync/create.go
@@ -34,7 +34,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/sync/delete.go
+++ b/internal/cli/opsmanager/admin/backup/sync/delete.go
@@ -31,7 +31,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/sync/describe.go
+++ b/internal/cli/opsmanager/admin/backup/sync/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/sync/list.go
+++ b/internal/cli/opsmanager/admin/backup/sync/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/admin/backup/sync/update.go
+++ b/internal/cli/opsmanager/admin/backup/sync/update.go
@@ -35,7 +35,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/apikeys/create.go
+++ b/internal/cli/opsmanager/agents/apikeys/create.go
@@ -35,7 +35,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/apikeys/delete.go
+++ b/internal/cli/opsmanager/agents/apikeys/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/apikeys/list.go
+++ b/internal/cli/opsmanager/agents/apikeys/list.go
@@ -30,7 +30,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/list.go
+++ b/internal/cli/opsmanager/agents/list.go
@@ -34,7 +34,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/upgrade.go
+++ b/internal/cli/opsmanager/agents/upgrade.go
@@ -34,7 +34,7 @@ var upgradeTemplate = "Updating agent versions to the latest available.\n"
 
 func (opts *UpgradeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/agents/versions/list.go
+++ b/internal/cli/opsmanager/agents/versions/list.go
@@ -30,7 +30,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/automation/describe.go
+++ b/internal/cli/opsmanager/automation/describe.go
@@ -32,7 +32,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/automation/status.go
+++ b/internal/cli/opsmanager/automation/status.go
@@ -32,7 +32,7 @@ type StatusOpts struct {
 
 func (opts *StatusOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/automation/update.go
+++ b/internal/cli/opsmanager/automation/update.go
@@ -37,7 +37,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/automation/watch.go
+++ b/internal/cli/opsmanager/automation/watch.go
@@ -32,7 +32,7 @@ type WatchOpts struct {
 
 func (opts *WatchOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/checkpoints_list.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list.go
@@ -39,7 +39,7 @@ type CheckpointsListOpts struct {
 
 func (opts *CheckpointsListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/config/describe.go
+++ b/internal/cli/opsmanager/backup/config/describe.go
@@ -37,7 +37,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/config/list.go
+++ b/internal/cli/opsmanager/backup/config/list.go
@@ -37,7 +37,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/config/update.go
+++ b/internal/cli/opsmanager/backup/config/update.go
@@ -47,7 +47,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/disable.go
+++ b/internal/cli/opsmanager/backup/disable.go
@@ -35,7 +35,7 @@ type DisableOpts struct {
 
 func (opts *DisableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/enable.go
+++ b/internal/cli/opsmanager/backup/enable.go
@@ -35,7 +35,7 @@ type EnableOpts struct {
 
 func (opts *EnableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/restores_list.go
+++ b/internal/cli/opsmanager/backup/restores_list.go
@@ -39,7 +39,7 @@ type RestoresListOpts struct {
 
 func (opts *RestoresListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/restores_start.go
+++ b/internal/cli/opsmanager/backup/restores_start.go
@@ -55,7 +55,7 @@ type RestoresStartOpts struct {
 
 func (opts *RestoresStartOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/snapshots/list.go
+++ b/internal/cli/opsmanager/backup/snapshots/list.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/snapshots/schedule/describe.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/backup/snapshots/schedule/update.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/update.go
@@ -45,7 +45,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/apply.go
+++ b/internal/cli/opsmanager/clusters/apply.go
@@ -37,7 +37,7 @@ type ApplyOpts struct {
 
 func (opts *ApplyOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/create.go
+++ b/internal/cli/opsmanager/clusters/create.go
@@ -38,7 +38,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/delete.go
+++ b/internal/cli/opsmanager/clusters/delete.go
@@ -38,7 +38,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/describe.go
+++ b/internal/cli/opsmanager/clusters/describe.go
@@ -36,7 +36,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -52,7 +52,7 @@ type IndexesCreateOpts struct {
 
 func (opts *IndexesCreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/list.go
+++ b/internal/cli/opsmanager/clusters/list.go
@@ -33,7 +33,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/restart.go
+++ b/internal/cli/opsmanager/clusters/restart.go
@@ -38,7 +38,7 @@ type RestartOpts struct {
 
 func (opts *RestartOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/shutdown.go
+++ b/internal/cli/opsmanager/clusters/shutdown.go
@@ -38,7 +38,7 @@ type ShutdownOpts struct {
 
 func (opts *ShutdownOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/startup.go
+++ b/internal/cli/opsmanager/clusters/startup.go
@@ -38,7 +38,7 @@ type StartupOpts struct {
 
 func (opts *StartupOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/unmanage.go
+++ b/internal/cli/opsmanager/clusters/unmanage.go
@@ -36,7 +36,7 @@ type UnmanageOpts struct {
 
 func (opts *UnmanageOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/clusters/update.go
+++ b/internal/cli/opsmanager/clusters/update.go
@@ -38,7 +38,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/dbusers/create.go
+++ b/internal/cli/opsmanager/dbusers/create.go
@@ -44,7 +44,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/dbusers/delete.go
+++ b/internal/cli/opsmanager/dbusers/delete.go
@@ -37,7 +37,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/dbusers/list.go
+++ b/internal/cli/opsmanager/dbusers/list.go
@@ -36,7 +36,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download.go
+++ b/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download.go
@@ -35,7 +35,7 @@ type DownloadOpts struct {
 
 func (opts *DownloadOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/featurepolicies/list.go
+++ b/internal/cli/opsmanager/featurepolicies/list.go
@@ -32,7 +32,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -37,7 +37,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/logs/jobs_collect.go
+++ b/internal/cli/opsmanager/logs/jobs_collect.go
@@ -41,7 +41,7 @@ type JobsCollectOpts struct {
 
 func (opts *JobsCollectOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/logs/jobs_delete.go
+++ b/internal/cli/opsmanager/logs/jobs_delete.go
@@ -32,7 +32,7 @@ type JobsDeleteOpts struct {
 
 func (opts *JobsDeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/logs/jobs_download.go
+++ b/internal/cli/opsmanager/logs/jobs_download.go
@@ -34,7 +34,7 @@ type JobsDownloadOpts struct {
 
 func (opts *JobsDownloadOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/logs/jobs_list.go
+++ b/internal/cli/opsmanager/logs/jobs_list.go
@@ -33,7 +33,7 @@ type JobsListOpts struct {
 
 func (opts *JobsListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/maintenance/create.go
+++ b/internal/cli/opsmanager/maintenance/create.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/maintenance/delete.go
+++ b/internal/cli/opsmanager/maintenance/delete.go
@@ -32,7 +32,7 @@ type DeleteOpts struct {
 
 func (opts *DeleteOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/maintenance/describe.go
+++ b/internal/cli/opsmanager/maintenance/describe.go
@@ -33,7 +33,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/maintenance/list.go
+++ b/internal/cli/opsmanager/maintenance/list.go
@@ -31,7 +31,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/maintenance/update.go
+++ b/internal/cli/opsmanager/maintenance/update.go
@@ -38,7 +38,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) init() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/metrics/databases_describe.go
+++ b/internal/cli/opsmanager/metrics/databases_describe.go
@@ -35,7 +35,7 @@ type DatabasesDescribeOpts struct {
 
 func (opts *DatabasesDescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/metrics/databases_list.go
+++ b/internal/cli/opsmanager/metrics/databases_list.go
@@ -34,7 +34,7 @@ type DatabasesListsOpts struct {
 
 func (opts *DatabasesListsOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/metrics/disks_describe.go
+++ b/internal/cli/opsmanager/metrics/disks_describe.go
@@ -35,7 +35,7 @@ type DisksDescribeOpts struct {
 
 func (opts *DisksDescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/metrics/disks_list.go
+++ b/internal/cli/opsmanager/metrics/disks_list.go
@@ -34,7 +34,7 @@ type DisksListsOpts struct {
 
 func (opts *DisksListsOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/metrics/process.go
+++ b/internal/cli/opsmanager/metrics/process.go
@@ -34,7 +34,7 @@ type ProcessOpts struct {
 
 func (opts *ProcessOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/monitoring/disable.go
+++ b/internal/cli/opsmanager/monitoring/disable.go
@@ -35,7 +35,7 @@ type DisableOpts struct {
 
 func (opts *DisableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/monitoring/enable.go
+++ b/internal/cli/opsmanager/monitoring/enable.go
@@ -51,7 +51,7 @@ type EnableOpts struct {
 
 func (opts *EnableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/monitoring/stop.go
+++ b/internal/cli/opsmanager/monitoring/stop.go
@@ -32,7 +32,7 @@ type StopOpts struct {
 
 func (opts *StopOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/owner/create.go
+++ b/internal/cli/opsmanager/owner/create.go
@@ -39,7 +39,7 @@ type CreateOpts struct {
 
 func (opts *CreateOpts) init() error {
 	var err error
-	opts.store, err = store.NewUnauthenticated(config.Default())
+	opts.store, err = store.New(store.PublicUnauthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/processes/describe.go
+++ b/internal/cli/opsmanager/processes/describe.go
@@ -33,7 +33,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/processes/list.go
+++ b/internal/cli/opsmanager/processes/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/security/enable.go
+++ b/internal/cli/opsmanager/security/enable.go
@@ -40,7 +40,7 @@ type EnableOpts struct {
 
 func (opts *EnableOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/servers/list.go
+++ b/internal/cli/opsmanager/servers/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/capture.go
+++ b/internal/cli/opsmanager/serverusage/capture.go
@@ -27,7 +27,7 @@ type CaptureOpts struct {
 
 func (opts *CaptureOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/download.go
+++ b/internal/cli/opsmanager/serverusage/download.go
@@ -39,7 +39,7 @@ var downloadMessage = "Download of %s completed.\n"
 
 func (opts *DownloadOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/describe.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/set.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/set.go
@@ -35,7 +35,7 @@ type SetOpts struct {
 
 func (opts *SetOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/projects/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/list.go
@@ -35,7 +35,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/describe.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/describe.go
@@ -35,7 +35,7 @@ type DescribeOpts struct {
 
 func (opts *DescribeOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/set.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/set.go
@@ -35,7 +35,7 @@ type SetOpts struct {
 
 func (opts *SetOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/softwarecomponents/list.go
+++ b/internal/cli/opsmanager/softwarecomponents/list.go
@@ -30,7 +30,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/opsmanager/versionmanifest/update.go
+++ b/internal/cli/opsmanager/versionmanifest/update.go
@@ -37,7 +37,7 @@ type UpdateOpts struct {
 
 func (opts *UpdateOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/performanceadvisor/namespaces/list.go
+++ b/internal/cli/performanceadvisor/namespaces/list.go
@@ -39,7 +39,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/performanceadvisor/slowquerylogs/list.go
@@ -41,7 +41,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/cli/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list.go
@@ -42,7 +42,7 @@ type ListOpts struct {
 
 func (opts *ListOpts) initStore() error {
 	var err error
-	opts.store, err = store.New(config.Default())
+	opts.store, err = store.New(store.PublicAuthenticatedPreset(config.Default()))
 	return err
 }
 

--- a/internal/store/ip_info.go
+++ b/internal/store/ip_info.go
@@ -38,7 +38,7 @@ func (s *Store) IPInfo() (*atlas.IPInfo, error) {
 
 // IPAddress gets the client's public ip by calling the atlas private endpoint
 func IPAddress() string {
-	s, err := NewPrivate(config.Default())
+	s, err := New(PrivateAuthenticatedPreset(config.Default()))
 	if err != nil {
 		return ""
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,7 +50,9 @@ type Store struct {
 	service       string
 	baseURL       string
 	caCertificate string
-	skipVerify    string
+	skipVerify    bool
+	username      string
+	password      string
 	client        interface{}
 }
 
@@ -66,7 +68,22 @@ var defaultTransport = &http.Transport{
 	ExpectContinueTimeout: expectContinueTimeout,
 }
 
-func customCATransport(ca []byte) http.RoundTripper {
+var skipVerifyTransport = &http.Transport{
+	ResponseHeaderTimeout: responseHeaderTimeout,
+	TLSHandshakeTimeout:   tlsHandshakeTimeout,
+	DialContext: (&net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: keepAlive,
+	}).DialContext,
+	MaxIdleConns:          maxIdleConns,
+	MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+	Proxy:                 http.ProxyFromEnvironment,
+	IdleConnTimeout:       idleConnTimeout,
+	ExpectContinueTimeout: expectContinueTimeout,
+	TLSClientConfig:       &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // this is optional for some users,
+}
+
+func customCATransport(ca []byte) *http.Transport {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(ca)
 	tlsClientConfig := &tls.Config{ //nolint:gosec // we let users set custom certificates
@@ -89,235 +106,246 @@ func customCATransport(ca []byte) http.RoundTripper {
 	}
 }
 
-func skipVerifyTransport() http.RoundTripper {
-	tlsClientConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // this is optional for some users
-	return &http.Transport{
-		ResponseHeaderTimeout: responseHeaderTimeout,
-		TLSHandshakeTimeout:   tlsHandshakeTimeout,
-		DialContext: (&net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: keepAlive,
-		}).DialContext,
-		MaxIdleConns:          maxIdleConns,
-		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-		Proxy:                 http.ProxyFromEnvironment,
-		IdleConnTimeout:       idleConnTimeout,
-		ExpectContinueTimeout: expectContinueTimeout,
-		TLSClientConfig:       tlsClientConfig,
+func (s *Store) httpClient(httpTransport http.RoundTripper) (*http.Client, error) {
+	if s.username == "" || s.password == "" {
+		client := http.DefaultClient
+		client.Transport = httpTransport
+		return client, nil
 	}
-}
-
-type Config interface {
-	Service() string
-	PublicAPIKey() string
-	PrivateAPIKey() string
-	OpsManagerURL() string
-	OpsManagerCACertificate() string
-	OpsManagerSkipVerify() string
-	OpsManagerVersionManifestURL() string
-}
-
-func authenticatedClient(c Config) (*http.Client, error) {
 	t := &digest.Transport{
-		Username: c.PublicAPIKey(),
-		Password: c.PrivateAPIKey(),
+		Username: s.username,
+		Password: s.password,
 	}
-	if caCertificate := c.OpsManagerCACertificate(); caCertificate != "" {
-		dat, err := ioutil.ReadFile(caCertificate)
-		if err != nil {
-			return nil, err
-		}
-		t.Transport = customCATransport(dat)
-	} else if skipVerify := c.OpsManagerSkipVerify(); skipVerify == yes {
-		t.Transport = skipVerifyTransport()
-	} else {
-		t.Transport = http.DefaultTransport
-	}
-
+	t.Transport = httpTransport
 	return t.Client()
 }
 
-func defaultClient(c Config) (*http.Client, error) {
-	client := http.DefaultClient
-	if caCertificate := c.OpsManagerCACertificate(); caCertificate != "" {
-		dat, err := ioutil.ReadFile(caCertificate)
+func (s *Store) transport() (*http.Transport, error) {
+	switch {
+	case s.caCertificate != "":
+		dat, err := ioutil.ReadFile(s.caCertificate)
 		if err != nil {
 			return nil, err
 		}
-		client.Transport = customCATransport(dat)
-	} else if skipVerify := c.OpsManagerSkipVerify(); skipVerify == yes {
-		client.Transport = skipVerifyTransport()
-	} else {
-		client.Transport = defaultTransport
-	}
-
-	return client, nil
-}
-
-// New get the appropriate client for the profile/service selected
-func New(c Config) (*Store, error) {
-	s := new(Store)
-	s.service = c.Service()
-
-	if configURL := c.OpsManagerURL(); configURL != "" {
-		s.baseURL = s.apiPath(configURL)
-	}
-	if caCertificate := c.OpsManagerCACertificate(); caCertificate != "" {
-		s.caCertificate = caCertificate
-	}
-	if skipVerify := c.OpsManagerSkipVerify(); skipVerify != yes {
-		s.skipVerify = skipVerify
-	}
-	client, err := authenticatedClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	switch s.service {
-	case config.CloudService:
-		err = s.setAtlasClient(client)
-	case config.CloudManagerService, config.OpsManagerService:
-		err = s.setOpsManagerClient(client)
+		return customCATransport(dat), nil
+	case s.skipVerify:
+		return skipVerifyTransport, nil
 	default:
-		return nil, fmt.Errorf("unsupported service: %s", s.service)
+		return defaultTransport, nil
 	}
-
-	return s, err
 }
 
-// NewUnauthenticated a client to interact with the Ops Manager APIs that don't require authentication
-func NewUnauthenticated(c Config) (*Store, error) {
-	s := new(Store)
-	s.service = c.Service()
+// Option configures a Store.
+type Option func(s *Store) error
 
-	if s.service != config.OpsManagerService {
-		return nil, fmt.Errorf("unsupported service: %s", s.service)
+// Options turns a list of Option instances into an Option.
+func Options(opts ...Option) Option {
+	return func(s *Store) error {
+		for _, opt := range opts {
+			if err := opt(s); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
-	if configURL := c.OpsManagerURL(); configURL != "" {
-		s.baseURL = s.apiPath(configURL)
+}
+
+// Service configures a service.
+func Service(service string) Option {
+	return func(s *Store) error {
+		s.service = service
+		return nil
 	}
-	if caCertificate := c.OpsManagerCACertificate(); caCertificate != "" {
+}
+
+func WithBaseURL(configURL string) Option {
+	return func(s *Store) error {
+		s.baseURL = configURL
+		return nil
+	}
+}
+
+func WithPublicPathBaseURL() Option {
+	return func(s *Store) error {
+		if s.service == config.CloudService {
+			s.baseURL += atlas.APIPublicV1Path
+			return nil
+		}
+		s.baseURL += opsmngr.APIPublicV1Path
+		return nil
+	}
+}
+
+func WithCACertificate(caCertificate string) Option {
+	return func(s *Store) error {
 		s.caCertificate = caCertificate
+		return nil
+	}
+}
+
+func SkipVerify() Option {
+	return func(s *Store) error {
+		s.skipVerify = true
+		return nil
+	}
+}
+
+type CredentialsGetter interface {
+	PublicAPIKey() string
+	PrivateAPIKey() string
+}
+
+func WithAuthentication(c CredentialsGetter) Option {
+	return func(s *Store) error {
+		s.username = c.PublicAPIKey()
+		s.password = c.PrivateAPIKey()
+		return nil
+	}
+}
+
+func withAtlasClient(client *http.Client) Option {
+	return func(s *Store) error {
+		opts := []atlas.ClientOpt{atlas.SetUserAgent(userAgent)}
+		if s.baseURL != "" {
+			opts = append(opts, atlas.SetBaseURL(s.baseURL))
+		}
+		c, err := atlas.New(client, opts...)
+		if err != nil {
+			return err
+		}
+		s.client = c
+		return nil
+	}
+}
+
+func withOpsManagerClient(client *http.Client) Option {
+	return func(s *Store) error {
+		opts := []opsmngr.ClientOpt{opsmngr.SetUserAgent(userAgent)}
+		if s.baseURL != "" {
+			opts = append(opts, opsmngr.SetBaseURL(s.baseURL))
+		}
+		c, err := opsmngr.New(client, opts...)
+		if err != nil {
+			return err
+		}
+
+		s.client = c
+		return nil
+	}
+}
+
+type TransportConfigGetter interface {
+	OpsManagerCACertificate() string
+	OpsManagerSkipVerify() string
+}
+
+func NetworkPresets(c TransportConfigGetter) Option {
+	options := make([]Option, 0)
+	if caCertificate := c.OpsManagerCACertificate(); caCertificate != "" {
+		options = append(options, WithCACertificate(caCertificate))
 	}
 	if skipVerify := c.OpsManagerSkipVerify(); skipVerify != yes {
-		s.skipVerify = skipVerify
+		options = append(options, SkipVerify())
 	}
-	client, err := defaultClient(c)
+	return Options(options...)
+}
+
+type Config interface {
+	CredentialsGetter
+	TransportConfigGetter
+	Service() string
+	OpsManagerURL() string
+}
+
+func PublicAuthenticatedPreset(c Config) Option {
+	options := []Option{Service(c.Service()), WithAuthentication(c)}
+	if configURL := c.OpsManagerURL(); configURL != "" {
+		options = append(options, WithBaseURL(configURL), WithPublicPathBaseURL())
+	}
+	options = append(options, NetworkPresets(c))
+	return Options(options...)
+}
+
+func PublicUnauthenticatedPreset(c Config) Option {
+	options := []Option{Service(c.Service())}
+	if configURL := c.OpsManagerURL(); configURL != "" {
+		options = append(options, WithBaseURL(configURL), WithPublicPathBaseURL())
+	}
+	options = append(options, NetworkPresets(c))
+	return Options(options...)
+}
+
+func PrivateAuthenticatedPreset(c Config) Option {
+	options := []Option{Service(c.Service()), WithAuthentication(c)}
+	if configURL := c.OpsManagerURL(); configURL != "" {
+		options = append(options, WithBaseURL(configURL))
+	}
+	options = append(options, NetworkPresets(c))
+	return Options(options...)
+}
+
+func PrivateUnauthenticatedPreset(c Config) Option {
+	options := []Option{Service(c.Service())}
+	if configURL := c.OpsManagerURL(); configURL != "" {
+		options = append(options, WithBaseURL(configURL))
+	}
+	options = append(options, NetworkPresets(c))
+	return Options(options...)
+}
+
+// New
+func New(opts ...Option) (*Store, error) {
+	store := new(Store)
+
+	// apply the list of options to Server
+	for _, opt := range opts {
+		if err := opt(store); err != nil {
+			return nil, err
+		}
+	}
+
+	httpTransport, err := store.transport()
 	if err != nil {
 		return nil, err
 	}
-	if err := s.setOpsManagerClient(client); err != nil {
+	client, err := store.httpClient(httpTransport)
+	if err != nil {
 		return nil, err
 	}
-	return s, nil
+
+	switch store.service {
+	case config.CloudService:
+		err = withAtlasClient(client)(store)
+	case config.CloudManagerService, config.OpsManagerService:
+		err = withOpsManagerClient(client)(store)
+	default:
+		return nil, fmt.Errorf("unsupported service: %s", store.service)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+type ManifestGetter interface {
+	Service() string
+	OpsManagerVersionManifestURL() string
 }
 
 // NewVersionManifest ets the appropriate client for the manifest version page
-func NewVersionManifest(c Config) (*Store, error) {
+func NewVersionManifest(c ManifestGetter) (*Store, error) {
 	s := new(Store)
 	s.service = c.Service()
 	if s.service != config.OpsManagerService {
 		return nil, fmt.Errorf("unsupported service: %s", s.service)
 	}
 	s.baseURL = versionManifestStaticPath
-
 	if baseURL := c.OpsManagerVersionManifestURL(); baseURL != "" {
 		s.baseURL = baseURL
 	}
-
-	client, err := defaultClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.setOpsManagerClient(client); err != nil {
+	if err := withOpsManagerClient(http.DefaultClient)(s); err != nil {
 		return nil, err
 	}
 
 	return s, nil
-}
-
-// NewPrivateUnauth gets the appropriate client for the atlas private api
-func NewPrivateUnauth(c Config) (*Store, error) {
-	s := new(Store)
-	s.service = c.Service()
-	if s.service != config.CloudService {
-		return nil, fmt.Errorf("unsupported service: %s", s.service)
-	}
-	s.baseURL = atlas.CloudURL
-
-	if configURL := c.OpsManagerURL(); configURL != "" {
-		s.baseURL = configURL
-	}
-
-	client, err := defaultClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if err2 := s.setAtlasClient(client); err2 != nil {
-		return nil, err2
-	}
-
-	return s, err
-}
-
-// NewPrivate gets the appropriate client for the atlas private api with authentication
-func NewPrivate(c Config) (*Store, error) {
-	s := new(Store)
-	s.service = c.Service()
-	if s.service != config.CloudService {
-		return nil, fmt.Errorf("unsupported service: %s", s.service)
-	}
-	s.baseURL = atlas.CloudURL
-
-	if configURL := c.OpsManagerURL(); configURL != "" {
-		s.baseURL = configURL
-	}
-
-	client, err := authenticatedClient(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if err2 := s.setAtlasClient(client); err2 != nil {
-		return nil, err2
-	}
-
-	return s, err
-}
-
-func (s *Store) setAtlasClient(client *http.Client) error {
-	opts := make([]atlas.ClientOpt, 0)
-	if s.baseURL != "" {
-		opts = append(opts, atlas.SetBaseURL(s.baseURL))
-	}
-	c, err := atlas.New(client, opts...)
-	if err != nil {
-		return err
-	}
-	c.UserAgent = userAgent
-	s.client = c
-	return nil
-}
-
-func (s *Store) setOpsManagerClient(client *http.Client) error {
-	opts := make([]opsmngr.ClientOpt, 0)
-	if s.baseURL != "" {
-		opts = append(opts, opsmngr.SetBaseURL(s.baseURL))
-	}
-	c, err := opsmngr.New(client, opts...)
-	if err != nil {
-		return err
-	}
-	c.UserAgent = userAgent
-	s.client = c
-	return nil
-}
-
-func (s *Store) apiPath(baseURL string) string {
-	if s.service == config.CloudService {
-		return baseURL + atlas.APIPublicV1Path
-	}
-	return baseURL + opsmngr.APIPublicV1Path
 }


### PR DESCRIPTION
## Proposed changes

Move from having 4 ways to create a new `Store` to a single one that takes functional options for configuration

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This has been on my TODO list for a long time, every time we add a new `New*` method I'm reminded of it. This moves  from multiple `New` methods that know what changes to set of configurations you need to pass to the constructor `With*` to reduce the impact of this I have also added a group of presets that have the default configs we have been using so far

