### PR TITLE
CLOUDP-87818: Adding validation for cluster name in the quickstart command

### DIFF
--- a/internal/cli/atlas/quickstart/prompt.go
+++ b/internal/cli/atlas/quickstart/prompt.go
@@ -79,7 +79,7 @@ func newDBUserPasswordQuestion(password, message string) *survey.Question {
 
 func newClusterNameQuestion(clusterName, message string, validation func(val interface{}) error) *survey.Question {
 	return &survey.Question{
-		Name: "clusterName",
+		Name:     "clusterName",
 		Validate: validation,
 		Prompt: &survey.Input{
 			Message: fmt.Sprintf("Cluster Name%s:", message),

--- a/internal/cli/atlas/quickstart/prompt.go
+++ b/internal/cli/atlas/quickstart/prompt.go
@@ -77,9 +77,10 @@ func newDBUserPasswordQuestion(password, message string) *survey.Question {
 	}
 }
 
-func newClusterNameQuestion(clusterName, message string) *survey.Question {
+func newClusterNameQuestion(clusterName, message string, validation func(val interface{}) error) *survey.Question {
 	return &survey.Question{
 		Name: "clusterName",
+		Validate: validation,
 		Prompt: &survey.Input{
 			Message: fmt.Sprintf("Cluster Name%s:", message),
 			Help:    usage.ClusterName,
@@ -164,7 +165,7 @@ func providerQuestion(provider string) *survey.Question {
 	return nil
 }
 
-func clusterNameQuestion(clusterName string) *survey.Question {
+func clusterNameQuestion(clusterName string, validation func(val interface{}) error) *survey.Question {
 	if clusterName != "" {
 		return nil
 	}
@@ -175,7 +176,7 @@ func clusterNameQuestion(clusterName string) *survey.Question {
 		message = fmt.Sprintf(" [Press Enter to use the auto-generated name '%s']", newClusterName)
 	}
 
-	return newClusterNameQuestion(newClusterName, message)
+	return newClusterNameQuestion(newClusterName, message, validation)
 }
 
 func dbUserPasswordQuestion(password string) (string, *survey.Question) {

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -497,11 +497,11 @@ func validateClusterName(val interface{}) error {
 	name, ok := val.(string)
 
 	if !ok {
-		return fmt.Errorf("the Cluster Name %s is not valid", name)
+		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
 	}
 
 	if matched, err := regexp.MatchString(clusterNameRegex, name); err != nil || !matched {
-		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens. ", name)
+		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
 	}
 
 	return nil

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"regexp"
 	"strings"
 	"syscall"
 
@@ -81,6 +82,7 @@ const (
 	accessListComment = "IP added with mongocli atlas quickstart"
 	atlasAdmin        = "atlasAdmin"
 	none              = "NONE"
+	clusterNameRegex = "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
 	mongoshURL        = "https://www.mongodb.com/try/download/shell"
 	atlasAccountURL   = "https://docs.atlas.mongodb.com/tutorial/create-atlas-account/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product/"
 	profileDocURL     = "https://docs.mongodb.com/mongocli/stable/configure/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product#std-label-mcli-configure"
@@ -312,7 +314,7 @@ func (opts *Opts) newProviderSettings() *atlas.ProviderSettings {
 func (opts *Opts) askClusterOptions() error {
 	var qs []*survey.Question
 
-	if q := clusterNameQuestion(opts.ClusterName); q != nil {
+	if q := clusterNameQuestion(opts.ClusterName, validateClusterName); q != nil {
 		qs = append(qs, q)
 	}
 
@@ -489,6 +491,21 @@ func (opts *Opts) validateUniqueUsername(val interface{}) error {
 	}
 
 	return fmt.Errorf("a user with this username %s already exists", username)
+}
+
+func validateClusterName(val interface{}) error {
+	name, ok := val.(string)
+
+	if !ok {
+		return fmt.Errorf("the Cluster Name %s is not valid", name)
+	}
+
+	if matched, err := regexp.MatchString(clusterNameRegex, name); err != nil || !matched {
+		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens. ", name)
+	}
+
+	return nil
+
 }
 
 func askOpenMongoShellDownloadPage() (bool, error) {

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -82,7 +82,7 @@ const (
 	accessListComment = "IP added with mongocli atlas quickstart"
 	atlasAdmin        = "atlasAdmin"
 	none              = "NONE"
-	clusterNameRegex = "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
+	clusterNameRegex  = "^[a-zA-Z0-9][a-zA-Z0-9-]*$"
 	mongoshURL        = "https://www.mongodb.com/try/download/shell"
 	atlasAccountURL   = "https://docs.atlas.mongodb.com/tutorial/create-atlas-account/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product/"
 	profileDocURL     = "https://docs.mongodb.com/mongocli/stable/configure/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product#std-label-mcli-configure"
@@ -505,7 +505,6 @@ func validateClusterName(val interface{}) error {
 	}
 
 	return nil
-
 }
 
 func askOpenMongoShellDownloadPage() (bool, error) {

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -497,11 +497,11 @@ func validateClusterName(val interface{}) error {
 	name, ok := val.(string)
 
 	if !ok {
-		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
+		return fmt.Errorf("the name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
 	}
 
 	if matched, err := regexp.MatchString(clusterNameRegex, name); err != nil || !matched {
-		return fmt.Errorf("the Cluster Name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
+		return fmt.Errorf("the name %s is not valid. The name can only contain ASCII letters, numbers, and hyphens", name)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-87818

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

I have added the validation to the cluster name question in the quickstart command

```
./bin/mongocli ./cmd/mongocli
➜  ~/workspace/mongoCLI git:(CLOUDP-87818) ✗ ./bin/mongocli atlas quickstart

[Set up your Atlas cluster]
X Sorry, your reply was invalid: the name asddsadasds!2232 is not valid. The name can only contain ASCII letters, numbers, and hyphens
? Cluster Name [Press Enter to use the auto-generated name 'Quickstart-1618939266']: Quickstart-1618939266
? Cloud Provider: AWS
? Cloud Provider Region: US_EAST_1
? Do you want to load sample data into Quickstart-1618939266? Yes
We are deploying your cluster...

```