### PR TITLE
feat: improve go fmt calls

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-STAGED_GO_FILES=$(git diff --cached --name-only | grep ".go$")
+STAGED_GO_FILES=$(git diff --cached --name-only | grep ".go$" | grep -v "mock")
 
 for FILE in ${STAGED_GO_FILES}
 do
     gofmt -w -s "${FILE}"
     goimports -w "${FILE}"
+    git add "${FILE}"
 done
 
 if [[ -n "${STAGED_GO_FILES}" ]]; then

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -14,21 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+STAGED_GO_FILES=$(git diff --name-only | grep ".go$" | grep -v "mock")
 
-set -euo pipefail
-
-find_files() {
-  find . -not \( \
-    \( \
-      -wholename '*mock*' \
-      -o -wholename '*third_party*' \
-    \) -prune \
-  \) \
-  \( -name '*.go' \)
-}
-
-echo "==> Formatting all files..."
-for FILE in $(find_files); do
+echo "==> Formatting changed go files..."
+for FILE in ${STAGED_GO_FILES}; do
     gofmt -w -s "${FILE}"
     goimports -w "${FILE}"
 done


### PR DESCRIPTION
## Proposed changes

Only format changed go on `make fmt`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

The `make fmt` command has become extremely slow and this has been bothering me for a while, the `find` function we used to use it's the bottle neck, so changing it to behave in a similar way as we handle the pre-commit and only format changed files

Also drive by fix to the pre commit to not format mocks and re add changed files 