### PR TITLE
fix: add json-path to output docs

### DIFF
--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
-	var slaveDelay float64 = 0
+	var slaveDelay float64
 	testCases := map[string]struct {
 		current  *opsmngr.AutomationConfig
 		expected *opsmngr.AutomationConfig

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_newReplicaSetProcessConfig(t *testing.T) {
-	var slaveDelay float64 = 0
+	var slaveDelay float64
 	omp := &opsmngr.Process{
 		Args26: opsmngr.Args26{
 			AuditLog: &opsmngr.AuditLog{

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -252,7 +252,7 @@ const (
 	ContainerRegion                 = "Atlas region where the container resides."
 	ContainerRegions                = "List of Atlas regions where the container resides."
 	FormatOut                       = `Output format.
-Valid values: json|go-template|go-template-file`
+Valid values: json|json-path|go-template|go-template-file`
 	TargetClusterID = `Unique identifier of the target cluster.
 For use only with automated restore jobs.`
 	TargetClusterName = `Name of the target cluster.


### PR DESCRIPTION
## Proposed changes

We were missing an option on the docs

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code
