### PR TITLE
feat: replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,72 +13,119 @@ linters-settings:
       - octalLiteral
   gocyclo:
     min-complexity: 15
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
   maligned:
     suggest-new: true
   misspell:
     locale: US
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
 linters:
   disable-all: true
   enable:
-    - bodyclose
-    - deadcode
-    - depguard
-    - dogsled
-    - errcheck
-    - errorlint # errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
-    - exhaustive
-    - exportloopref
-    - gochecknoinits
-    - goconst
-    - gocritic
-    - gocyclo
+    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
+    - deadcode # Finds unused code [fast: false, auto-fix: false]
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: false, auto-fix: false]
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
+    - exhaustive # check exhaustiveness of enum switch statements [fast: false, auto-fix: false]
+    - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
+    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
+    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
+    - gocritic # Provides many diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
+    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
     - godot # Check if comments end in a period [fast: true, auto-fix: true]
-    - gofmt
-    - goimports
-    - golint
-    - gomnd
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ifshort
-    - ineffassign
-    - makezero
-    - misspell
-    - nakedret
-    - noctx
-    - nolintlint
-    - predeclared
-    - rowserrcheck
-    - staticcheck
-    - structcheck
-    - stylecheck
-    - thelper
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - varcheck
-    - whitespace
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
+    - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
+    - gosec # Inspects source code for security problems [fast: false, auto-fix: false]
+    - gosimple # Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
+    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
+    - ifshort # Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
+    - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
+    - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
+    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
+    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
+    - noctx # noctx finds sending http request without context.Context [fast: false, auto-fix: false]
+    - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
+    - predeclared # find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
+    - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
+    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
+    - structcheck # Finds unused struct fields [fast: false, auto-fix: false]
+    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
+    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
+    - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
+    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
+    - unused # Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
+    - varcheck # Finds unused global variables and constants [fast: false, auto-fix: false]
+    - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 
   # don't enable:
-  # - asciicheck
-  # - dupl
-  # - funlen
-  # - gochecknoglobals
-  # - gocognit
-  # - godox
-  # - goerr113
-  # - lll
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - wsl
+  # - asciicheck: Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
+  # - cyclop: checks function and package cyclomatic complexity [fast: false, auto-fix: false]
+  # - dupl: Tool for code clone detection [fast: true, auto-fix: false]
+  # - durationcheck: check for two durations multiplied together [fast: false, auto-fix: false]
+  # - exhaustivestruct: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
+  # - forbidigo: Forbids identifiers [fast: true, auto-fix: false]
+  # - forcetypeassert: finds forced type assertions [fast: true, auto-fix: false]
+  # - funlen: Tool for detection of long functions [fast: true, auto-fix: false]
+  # - gci: Gci control golang package import order and make it always deterministic. [fast: true, auto-fix: true]
+  # - gochecknoglobals: check that no global variables exist [fast: true, auto-fix: false]
+  # - gocognit: Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
+  # - godox: Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
+  # - goerr113: Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
+  # - gofumpt: Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
+  # - goheader: Checks is file header matches to pattern [fast: true, auto-fix: false]
+  # - gomoddirectives: Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
+  # - gomodguard: Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
+  # - importas: Enforces consistent import aliases [fast: false, auto-fix: false]
+  # - interfacer: Linter that suggests narrower interface types [fast: false, auto-fix: false]
+  # - lll: Reports long lines [fast: true, auto-fix: false]
+  # - maligned: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
+  # - nestif: Reports deeply nested if statements [fast: true, auto-fix: false]
+  # - nilerr: Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
+  # - nlreturn: nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
+  # - paralleltest: paralleltest detects missing usage of t.Parallel() method in your Go test [fast: true, auto-fix: false]
+  # - prealloc: Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
+  # - promlinter: Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
+  # - scopelint: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
+  # - sqlclosecheck: Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
+  # - tagliatelle: Checks the struct tags. [fast: true, auto-fix: false]
+  # - testpackage: linter that makes you use a separate _test package [fast: true, auto-fix: false]
+  # - tparallel: tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
+  # - wastedassign: wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
+  # - wrapcheck: Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
+  # - wsl: Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
 
 run:
   tests: true

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -154,7 +154,7 @@ func (opts *CreateOpts) providerName() string {
 
 func (opts *CreateOpts) newReplicationSpec() atlas.ReplicationSpec {
 	var (
-		readOnlyNodes int64 = 0
+		readOnlyNodes int64
 		Priority      int64 = 7
 	)
 	replicationSpec := atlas.ReplicationSpec{

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -40,6 +40,8 @@ func (opts *DeleteOpts) Run() error {
 	return opts.Delete(opts.store.DeleteCluster, opts.ConfigProjectID())
 }
 
+// DeleteBuilder
+//
 // mongocli atlas cluster(s) delete <name> --projectId projectId [--confirm].
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -143,11 +143,7 @@ func (opts *CreateOpts) validate() error {
 	if err := validate.FlagInSlice(opts.awsIamType, flag.AWSIAMType, validAWSIAMFlags); err != nil {
 		return err
 	}
-	if err := validate.FlagInSlice(opts.ldapType, flag.LDAPType, validLDAPFlags); err != nil {
-		return err
-	}
-
-	return nil
+	return validate.FlagInSlice(opts.ldapType, flag.LDAPType, validLDAPFlags)
 }
 
 // mongocli atlas dbuser(s) create

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -149,9 +149,7 @@ func (opts *Opts) Run() error {
 	fmt.Printf(quickstartTemplate, opts.DBUsername, opts.DBUserPassword, cluster.SrvAddress)
 
 	if runMongoShell {
-		if err := mongosh.Run(config.MongoShellPath(), opts.DBUsername, opts.DBUserPassword, cluster.SrvAddress); err != nil {
-			return err
-		}
+		return mongosh.Run(config.MongoShellPath(), opts.DBUsername, opts.DBUserPassword, cluster.SrvAddress)
 	}
 
 	return nil
@@ -208,11 +206,7 @@ func (opts *Opts) loadSampleData() error {
 
 	opts.SampleDataJobID = sampleDataJob.ID
 
-	if er := opts.Watch(opts.sampleDataWatcher); er != nil {
-		return er
-	}
-
-	return nil
+	return opts.Watch(opts.sampleDataWatcher)
 }
 
 func (opts *Opts) sampleDataWatcher() (bool, error) {
@@ -281,7 +275,7 @@ func (opts *Opts) newCluster() *atlas.Cluster {
 
 func (opts *Opts) newReplicationSpec() atlas.ReplicationSpec {
 	var (
-		readOnlyNodes int64 = 0
+		readOnlyNodes int64
 		priority      int64 = 7
 		shards        int64 = shards
 		members       int64 = members
@@ -521,10 +515,7 @@ func askMongoShellAndSetConfig() error {
 	}
 
 	config.SetMongoShellPath(mongoShellPath)
-	if err := config.Save(); err != nil {
-		return err
-	}
-	return nil
+	return config.Save()
 }
 
 func askAtlasAccountAndProfile() error {
@@ -548,25 +539,17 @@ func openBrowserProfile() error {
 		return err
 	}
 
-	if err := browser.OpenURL(profileDocURL); err != nil {
-		return err
-	}
-
-	return nil
+	return browser.OpenURL(profileDocURL)
 }
 
 func openBrowserAtlasAccount() error {
-	openBrowserAtlasAccount := false
 	q := newAtlasAccountQuestionOpenBrowser()
+	var openBrowserAtlasAccount bool
 	if err := survey.AskOne(q, &openBrowserAtlasAccount); !openBrowserAtlasAccount || err != nil {
 		return err
 	}
 
-	if err := browser.OpenURL(atlasAccountURL); err != nil {
-		return err
-	}
-
-	return nil
+	return browser.OpenURL(atlasAccountURL)
 }
 
 func (opts *Opts) defaultRegions() ([]string, error) {

--- a/internal/cli/global_opts.go
+++ b/internal/cli/global_opts.go
@@ -67,10 +67,7 @@ func (opts *GlobalOpts) ValidateProjectID() error {
 	if opts.ConfigProjectID() == "" {
 		return errMissingProjectID
 	}
-	if err := validate.ObjectID(opts.ConfigProjectID()); err != nil {
-		return err
-	}
-	return nil
+	return validate.ObjectID(opts.ConfigProjectID())
 }
 
 // ValidateOrgID validates orgID.
@@ -78,10 +75,7 @@ func (opts *GlobalOpts) ValidateOrgID() error {
 	if opts.ConfigOrgID() == "" {
 		return ErrMissingOrgID
 	}
-	if err := validate.ObjectID(opts.ConfigOrgID()); err != nil {
-		return err
-	}
-	return nil
+	return validate.ObjectID(opts.ConfigOrgID())
 }
 
 func DeploymentStatus(baseURL, projectID string) string {

--- a/internal/cli/opsmanager/clusters/delete.go
+++ b/internal/cli/opsmanager/clusters/delete.go
@@ -145,10 +145,7 @@ func (opts *DeleteOpts) removeClusterFromAutomation() error {
 	}
 
 	// Wait for changes being deployed on automation
-	if err := opts.Watch(opts.watcher); err != nil {
-		return err
-	}
-	return nil
+	return opts.Watch(opts.watcher)
 }
 
 func (opts *DeleteOpts) shutdownCluster() error {
@@ -167,11 +164,7 @@ func (opts *DeleteOpts) shutdownCluster() error {
 	}
 
 	// Wait for changes being deployed on automation
-	if err := opts.Watch(opts.watcher); err != nil {
-		return err
-	}
-
-	return nil
+	return opts.Watch(opts.watcher)
 }
 
 func (opts *DeleteOpts) watcher() (bool, error) {

--- a/internal/convert/cluster_config_test.go
+++ b/internal/convert/cluster_config_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestClusterConfig_PatchAutomationConfig(t *testing.T) {
-	var slaveDelay float64 = 0
+	var slaveDelay float64
 	testCases := map[string]struct {
 		current  *opsmngr.AutomationConfig
 		expected *opsmngr.AutomationConfig

--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -427,7 +427,7 @@ func (p *ProcessConfig) process() *opsmngr.Process {
 
 // member maps convert.ProcessConfig -> opsmngr.Member.
 func (p *ProcessConfig) member(i int) opsmngr.Member {
-	var slaveDelay float64 = 0
+	var slaveDelay float64
 	m := opsmngr.Member{
 		ID:           i,
 		ArbiterOnly:  false,

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_newReplicaSetProcessConfig(t *testing.T) {
-	var slaveDelay float64 = 0
+	var slaveDelay float64
 	omp := &opsmngr.Process{
 		Args26: opsmngr.Args26{
 			AuditLog: &opsmngr.AuditLog{

--- a/internal/docs/rest/rest.go
+++ b/internal/docs/rest/rest.go
@@ -54,10 +54,7 @@ func GenReSTTree(cmd *cobra.Command, dir string) error {
 	}
 	defer f.Close()
 
-	if err := GenReSTCustom(cmd, f); err != nil {
-		return err
-	}
-	return nil
+	return GenReSTCustom(cmd, f)
 }
 
 const toc = `

--- a/internal/test/fixture/automation_configs.go
+++ b/internal/test/fixture/automation_configs.go
@@ -26,9 +26,9 @@ const (
 	defaultSizeThresholdMB   = 1000
 )
 
-func AutomationConfig() *opsmngr.AutomationConfig {
-	var slaveDelay float64 = 0
+var slaveDelay float64
 
+func AutomationConfig() *opsmngr.AutomationConfig {
 	return &opsmngr.AutomationConfig{
 		Auth: opsmngr.Auth{
 			AutoAuthMechanism: "MONGODB-CR",
@@ -189,7 +189,6 @@ func AutomationConfigWithMonitoring() *opsmngr.AutomationConfig {
 }
 
 func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.AutomationConfig {
-	var slaveDelay float64 = 0
 	return &opsmngr.AutomationConfig{
 		Processes: []*opsmngr.Process{
 			{
@@ -265,7 +264,6 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 }
 
 func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.AutomationConfig {
-	var slaveDelay float64 = 0
 	return &opsmngr.AutomationConfig{
 		Auth: opsmngr.Auth{
 			DeploymentAuthMechanisms: []string{},


### PR DESCRIPTION
## Proposed changes

`golint` has been deprecated and the recommended replacement is `revive`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

