### PR TITLE
feat: use Atlas default major version API for quickstart

### DIFF
--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -41,14 +41,13 @@ import (
 )
 
 const (
-	Use        = "atlas"
-	atlasShort = "Atlas operations."
+	Use = "atlas"
 )
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   Use,
-		Short: atlasShort,
+		Short: "Atlas operations.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			config.SetService(config.CloudService)
 

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -224,7 +224,7 @@ Some of the cluster configuration options are available via flags but for full c
 		},
 	}
 
-	currentMDBVersion, _ := DefaultMongoDBMajorVersion()
+	currentMDBVersion, _ := cli.DefaultMongoDBMajorVersion()
 
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "", usage.Provider)
 	cmd.Flags().StringVarP(&opts.region, flag.Region, flag.RegionShort, "", usage.Region)
@@ -244,19 +244,4 @@ Some of the cluster configuration options are available via flags but for full c
 	_ = cmd.MarkFlagFilename(flag.File)
 
 	return cmd
-}
-
-var defaultMongoDBMajorVersion string
-
-func DefaultMongoDBMajorVersion() (string, error) {
-	if defaultMongoDBMajorVersion != "" {
-		return defaultMongoDBMajorVersion, nil
-	}
-	s, err := store.New(store.PrivateUnauthenticatedPreset(config.Default()))
-	if err != nil {
-		return "", err
-	}
-	defaultMongoDBMajorVersion, _ = s.DefaultMongoDBVersion()
-
-	return defaultMongoDBMajorVersion, nil
 }

--- a/internal/cli/atlas_cluster_opts.go
+++ b/internal/cli/atlas_cluster_opts.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"github.com/mongodb/mongocli/internal/config"
+	"github.com/mongodb/mongocli/internal/store"
+)
+
+var defaultMongoDBMajorVersion string
+
+func DefaultMongoDBMajorVersion() (string, error) {
+	if defaultMongoDBMajorVersion != "" {
+		return defaultMongoDBMajorVersion, nil
+	}
+	s, err := store.New(store.PrivateUnauthenticatedPreset(config.Default()))
+	if err != nil {
+		return "", err
+	}
+	defaultMongoDBMajorVersion, _ = s.DefaultMongoDBVersion()
+
+	return defaultMongoDBMajorVersion, nil
+}

--- a/internal/cli/atlas_cluster_opts.go
+++ b/internal/cli/atlas_cluster_opts.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/internal/cli/opsmanager/ops_manager.go
+++ b/internal/cli/opsmanager/ops_manager.go
@@ -42,11 +42,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	use = "ops-manager"
-)
-
 func Builder() *cobra.Command {
+	const use = "ops-manager"
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: []string{"om"},


### PR DESCRIPTION
## Proposed changes

Came to fix a typo but a couple of other small fixes showed up

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

- We have a function to get the current major version from atlas, using that instead of a hardcoded value
- From user feedback we know some users may want to set the tier for the cluster, we won't ask it but a flag is now available for it
- Fix a typo