### PR TITLE
Update docs output folder to /command instead of /reference

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -993,16 +993,16 @@ tasks:
       - func: "generate docs"
       - command: archive.targz_pack
         params:
-          target: src/github.com/mongodb/mongocli/docs/reference.tgz
+          target: src/github.com/mongodb/mongocli/docs/command.tgz
           source_dir: src/github.com/mongodb/mongocli/docs
           include:
-            - "reference/*.txt"
+            - "command/*.txt"
       - command: s3.put
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
-          local_file: src/github.com/mongodb/mongocli/docs/reference.tgz
-          remote_file: ${project}/docs/${revision}_${created_at}/reference.tgz
+          local_file: src/github.com/mongodb/mongocli/docs/command.tgz
+          remote_file: ${project}/docs/${revision}_${created_at}/command.tgz
           bucket: mongodb-mongocli-build
           permissions: public-read
           content_type: ${content_type|application/x-gzip}

--- a/internal/docs/main.go
+++ b/internal/docs/main.go
@@ -24,13 +24,13 @@ import (
 
 func main() {
 	var profile string
-	if err := os.MkdirAll("./docs/reference", 0766); err != nil {
+	if err := os.MkdirAll("./docs/command", 0766); err != nil {
 		log.Fatal(err)
 	}
 
 	mongocli := root.Builder(&profile, []string{})
 
-	if err := rest.GenReSTTree(mongocli, "./docs/reference"); err != nil {
+	if err := rest.GenReSTTree(mongocli, "./docs/command"); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/docs/rest/rest.go
+++ b/internal/docs/rest/rest.go
@@ -147,7 +147,7 @@ func GenReSTCustom(cmd *cobra.Command, w io.Writer) error {
 			}
 			cname := name + " " + child.Name()
 			ref = strings.ReplaceAll(cname, " ", separator)
-			buf.WriteString(fmt.Sprintf("   %s </reference/%s>\n", child.Name(), ref))
+			buf.WriteString(fmt.Sprintf("   %s </command/%s>\n", child.Name(), ref))
 		}
 		buf.WriteString("\n")
 	}


### PR DESCRIPTION
This PR renames the auto-generated docs output directory from "/reference" to "/command". On the Docs side, we decided that we should still have a separate "/reference" directory for any miscellaneous reference material that we might need to provide in the future.

This also means that the auto-generated command reference pages will have a nice semantic URL like `https://docs.mongodb.com/mongocli/v1.16/command/mongocli-atlas-clusters-create/`

[Docs Staged Example](https://docs-mongodbcom-staging.corp.mongodb.com/mongocli/docsworker-xlarge/autogen-ref-docs/command/mongocli/)

@gssbzn I did my best but please let me know if I missed anything :)