### PR TITLE
CLOUDP-92550: Add --default flag to the Quickstart command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tangzero/inflector v1.0.0
-	go.mongodb.org/atlas v0.9.1-0.20210705075343-8c2d9de1e387
+	go.mongodb.org/atlas v0.9.1-0.20210707084630-612962074f5e
 	go.mongodb.org/ops-manager v0.23.1-0.20210705152314-3c9ae47df7fc
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mongodb.org/atlas v0.9.0/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
-go.mongodb.org/atlas v0.9.1-0.20210705075343-8c2d9de1e387 h1:99SGmt+HBbEdRLrbZ5yKei6PhyY9vmwUV7l1ryawO/Q=
-go.mongodb.org/atlas v0.9.1-0.20210705075343-8c2d9de1e387/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
+go.mongodb.org/atlas v0.9.1-0.20210707084630-612962074f5e h1:U22iuDaPngROuDU2kZyUzlBs2fwSlr3tfNi+EREvzqc=
+go.mongodb.org/atlas v0.9.1-0.20210707084630-612962074f5e/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
 go.mongodb.org/ops-manager v0.23.1-0.20210705152314-3c9ae47df7fc h1:QjZ6kIIPTAPXPrfolIz4CspB0ZT1qAO9ELVcWZn1W3A=
 go.mongodb.org/ops-manager v0.23.1-0.20210705152314-3c9ae47df7fc/go.mod h1:9YkQ4+hZNLQchJZphBAHobFh//C6kban4P9hFamKVbI=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/cli/atlas/quickstart/dbuser_setup.go
+++ b/internal/cli/atlas/quickstart/dbuser_setup.go
@@ -46,7 +46,7 @@ func (opts *Opts) askDBUserOptions() error {
 	}
 
 	if opts.DBUserPassword == "" {
-		pwd, err := GeneratePassword()
+		pwd, err := generatePassword()
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func (opts *Opts) newDatabaseUser() *atlas.DatabaseUser {
 	}
 }
 
-func GeneratePassword() (string, error) {
+func generatePassword() (string, error) {
 	const passwordLength = 12
 	pwd, err := randgen.GenerateRandomBase64String(passwordLength)
 	if err != nil {

--- a/internal/cli/atlas/quickstart/dbuser_setup.go
+++ b/internal/cli/atlas/quickstart/dbuser_setup.go
@@ -46,12 +46,11 @@ func (opts *Opts) askDBUserOptions() error {
 	}
 
 	if opts.DBUserPassword == "" {
-		const passwordLength = 12
-		pwd, err := randgen.GenerateRandomBase64String(passwordLength)
+		pwd, err := GeneratePassword()
 		if err != nil {
 			return err
 		}
-		opts.DBUsername = pwd
+		opts.DBUserPassword = pwd
 		message := fmt.Sprintf(" [Press Enter to use an auto-generated password '%s']", pwd)
 
 		qs = append(qs, newDBUserPasswordQuestion(pwd, message))
@@ -96,4 +95,14 @@ func (opts *Opts) newDatabaseUser() *atlas.DatabaseUser {
 		DatabaseName: convert.AdminDB,
 		Username:     opts.DBUsername,
 	}
+}
+
+func GeneratePassword() (string, error) {
+	const passwordLength = 12
+	pwd, err := randgen.GenerateRandomBase64String(passwordLength)
+	if err != nil {
+		return "", err
+	}
+
+	return pwd, nil
 }

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -302,7 +302,7 @@ func (opts *Opts) defaultValues() error {
 	}
 
 	if opts.DBUserPassword == "" {
-		pwd, err := GeneratePassword()
+		pwd, err := generatePassword()
 		if err != nil {
 			return err
 		}

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -328,8 +328,7 @@ func (opts *Opts) defaultValues() error {
 //	[--projectId projectId]
 //	[--username username]
 //	[--password password]
-//	[--skipMongosh skipMongosh]
-//  [--default]
+//	[--skipMongosh skipMongosh] [--default]
 func Builder() *cobra.Command {
 	opts := &Opts{}
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -45,6 +45,17 @@ username: %s
 password: %s
 `
 
+const quickstartTemplateIntro = `You are creating a new Atlas cluster and enabling access to it.
+
+Press [Enter] to use the default values.
+
+Enter [?] on any option to get help.
+`
+
+const quickstartTemplateCluster = `
+Creating your cluster... [It's safe to 'Ctrl + C']
+`
+
 const (
 	replicaSet      = "REPLICASET"
 	atlasM2         = "M2"
@@ -52,6 +63,8 @@ const (
 	mongoshURL      = "https://www.mongodb.com/try/download/shell"
 	atlasAccountURL = "https://docs.atlas.mongodb.com/tutorial/create-atlas-account/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product/"
 	profileDocURL   = "https://docs.mongodb.com/mongocli/stable/configure/?utm_campaign=atlas_quickstart&utm_source=mongocli&utm_medium=product#std-label-mcli-configure"
+	aws             = "AWS"
+	region          = "US_EAST_1"
 )
 
 type Opts struct {
@@ -71,6 +84,7 @@ type Opts struct {
 	SkipMongosh         bool
 	runMongoShell       bool
 	mongoShellInstalled bool
+	defaultValue        bool
 	store               store.AtlasClusterQuickStarter
 }
 
@@ -81,12 +95,7 @@ func (opts *Opts) initStore() error {
 }
 
 func (opts *Opts) Run() error {
-	fmt.Print(`You are creating a new Atlas cluster and enabling access to it.
-
-Press [Enter] to use the default values.
-
-Enter [?] on any option to get help.
-`)
+	fmt.Print(quickstartTemplateIntro)
 
 	if err := opts.createCluster(); err != nil {
 		return err
@@ -114,9 +123,8 @@ We are deploying %s...
 
 	opts.setupCloseHandler()
 
-	fmt.Print(`
-Creating your cluster... [It's safe to 'Ctrl + C']
-`)
+	fmt.Print(quickstartTemplateCluster)
+
 	// Watch cluster creation
 	if er := opts.Watch(opts.clusterCreationWatcher); er != nil {
 		return er
@@ -257,6 +265,32 @@ func (opts *Opts) providerAndRegionToConstant() {
 	opts.Region = strings.ReplaceAll(strings.ToUpper(opts.Region), "-", "_")
 }
 
+func (opts *Opts) defaultValues() error {
+	if !opts.defaultValue {
+		return nil
+	}
+
+	opts.SkipSampleData = true
+	opts.SkipMongosh = true
+	opts.ClusterName = opts.defaultName
+	opts.Provider = aws
+	opts.Region = region
+	opts.tier = atlasM2
+	opts.DBUsername = opts.defaultName
+
+	pwd, err := GeneratePassword()
+	if err != nil {
+		return err
+	}
+	opts.DBUserPassword = pwd
+
+	if publicIP := store.IPAddress(); publicIP != "" {
+		opts.IPAddresses = []string{publicIP}
+	}
+
+	return nil
+}
+
 // Builder
 // mongocli atlas dbuser(s) quickstart
 //	[--clusterName clusterName]
@@ -265,7 +299,8 @@ func (opts *Opts) providerAndRegionToConstant() {
 //	[--projectId projectId]
 //	[--username username]
 //	[--password password]
-//	[--skipMongosh skipMongosh].
+//	[--skipMongosh skipMongosh]
+//  [--default]	.
 func Builder() *cobra.Command {
 	opts := &Opts{}
 	cmd := &cobra.Command{
@@ -290,6 +325,10 @@ func Builder() *cobra.Command {
 			const base10 = 10
 			opts.defaultName = "Quickstart-" + strconv.FormatInt(time.Now().Unix(), base10)
 			opts.providerAndRegionToConstant()
+
+			if err := opts.defaultValues(); err != nil {
+				return err
+			}
 			return opts.Run()
 		},
 	}
@@ -303,6 +342,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DBUserPassword, flag.Password, "", usage.Password)
 	cmd.Flags().BoolVar(&opts.SkipSampleData, flag.SkipSampleData, false, usage.SkipSampleData)
 	cmd.Flags().BoolVar(&opts.SkipMongosh, flag.SkipMongosh, false, usage.SkipMongosh)
+	cmd.Flags().BoolVarP(&opts.defaultValue, flag.Default, "Y", false, usage.Default)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -15,6 +15,7 @@
 package quickstart
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -56,8 +57,8 @@ const quickstartTemplateCluster = `
 Creating your cluster... [It's safe to 'Ctrl + C']
 `
 const quickstartTemplateIPNotFound = `
-We could not find your public IP address. Please run "mongocli atlas accesslist create"" to add your IP address to the Atlas access list. 
-`
+We could not find your public IP address. To add your IP address run:
+  mongocli atlas accesslist create`
 
 const (
 	replicaSet       = "REPLICASET"
@@ -313,7 +314,7 @@ func (opts *Opts) defaultValues() error {
 		if publicIP := store.IPAddress(); publicIP != "" {
 			opts.IPAddresses = []string{publicIP}
 		} else {
-			fmt.Print(quickstartTemplateIPNotFound)
+			return errors.New(quickstartTemplateIPNotFound)
 		}
 	}
 

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -328,7 +328,8 @@ func (opts *Opts) defaultValues() error {
 //	[--projectId projectId]
 //	[--username username]
 //	[--password password]
-//	[--skipMongosh skipMongosh] [--default]
+//	[--skipMongosh skipMongosh]
+//	[--default]
 func Builder() *cobra.Command {
 	opts := &Opts{}
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -15,7 +15,6 @@
 package quickstart
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -314,7 +313,7 @@ func (opts *Opts) defaultValues() error {
 		if publicIP := store.IPAddress(); publicIP != "" {
 			opts.IPAddresses = []string{publicIP}
 		} else {
-			return errors.New(quickstartTemplateIPNotFound)
+			_, _ = fmt.Fprintln(os.Stderr, quickstartTemplateIPNotFound)
 		}
 	}
 

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -249,5 +249,6 @@ const (
 	MonthlySnapshotRetentionMonths  = "monthlySnapshotRetentionMonths"  // MonthlySnapshotRetentionMonths flag
 	Policy                          = "policy"                          // Policy flag
 	SystemID                        = "systemId"                        // SystemID flag
+	Default                         = "default"                         // Default flag
 
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -254,6 +254,7 @@ const (
 	SkipSampleData                  = "Don't load sample data into your Atlas Cluster."
 	ContainerRegion                 = "Atlas region where the container resides."
 	ContainerRegions                = "List of Atlas regions where the container resides."
+	Default                         = "Run the Quickstart command with all the auto generated values to deploy and access an Atlas cluster."
 	FormatOut                       = `Output format.
 Valid values: json|json-path|go-template|go-template-file`
 	TargetClusterID = `Unique identifier of the target cluster.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -254,7 +254,7 @@ const (
 	SkipSampleData                  = "Don't load sample data into your Atlas Cluster."
 	ContainerRegion                 = "Atlas region where the container resides."
 	ContainerRegions                = "List of Atlas regions where the container resides."
-	Default                         = "Run the Quickstart command with all the auto generated values to deploy and access an Atlas cluster."
+	QuickstartDefault               = "Run the Quickstart command with all the auto generated values to deploy and access an Atlas cluster."
 	FormatOut                       = `Output format.
 Valid values: json|json-path|go-template|go-template-file`
 	TargetClusterID = `Unique identifier of the target cluster.


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Added a new `--default|Y` flag to the quickstart command.

Default values set by the flag:

- ClusterName: Quickstart-1624002722 (Autogenerated)
- Cloud Provider: AWS
- Tier: M2
- Region: US_EAST_1
- Sample data: No
- DB user Username: Quickstart-1624002776 (Autogenerated)
- DB Password: akxxR3dBZ05n (Autogenerated)
- Access List Entry: Public IP address of the user; None if the call returns an error
- MongoShell: No


<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-92550

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
```
./bin/mongocli atlas quickstart --default
You are creating a new Atlas cluster and enabling access to it.

Press [Enter] to use the default values.

Enter [?] on any option to get help.

We are deploying Quickstart-1625554688...

Creating your cluster... [It's safe to 'Ctrl + C']
|
Now you can connect to your Atlas cluster with: mongosh -u Quickstart-1625554688 -p elt5SHpdUE9h mongodb+srv://quickstart-1625554688.ajlj3.mongodb-dev.net
```