### PR TITLE
CLOUDP-94311: Include generated docs in release tasks an notifications

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -375,6 +375,8 @@ functions:
           - evergreen_user
           - evergreen_api_key
           - release_slack_channel
+          - revision
+          - created_at
         binary: build/package/send-slack-notification.sh
   "generate download archive json":
     - command: shell.exec
@@ -1569,7 +1571,7 @@ buildvariants:
     tasks:
       - name: ".e2e .clusters .opsmanager"
   - name: generate_docs
-    display_name: "Generate Docs"
+    display_name: "Generate Preview Docs"
     run_on:
       - rhel70-small
     expansions:
@@ -1628,6 +1630,15 @@ buildvariants:
       go_bin: "/opt/golang/go1.16/bin"
     tasks:
       - name: release
+  - name: release_generate_docs
+    display_name: "Generate Stable Docs"
+    run_on:
+      - rhel70-small
+    expansions:
+      go_root: "/opt/golang/go1.16"
+      go_bin: "/opt/golang/go1.16/bin"
+    tasks:
+      - name: ".docs"
   - name: release_publish_42
     display_name: "Publish yum/apt 4.2"
     run_on:

--- a/build/package/send-slack-notification.sh
+++ b/build/package/send-slack-notification.sh
@@ -34,7 +34,7 @@ curl --header "Api-User:${evergreen_user:?}" \
        },
        {
        	"title": "command.tgz",
-       	"title_link": "https://mongodb-mongocli-build.s3.amazonaws.com/mongocli-master/docs/'${revision-}'_'${created_at-}'/command.tgz",
+       	"title_link": "https://mongodb-mongocli-build.s3.amazonaws.com/mongocli-master/docs/'"${revision-}"'_'"${created_at-}"'/command.tgz",
        	"author_name": "Generated Docs",
        	"fallback": "new docs",
 	      "author_icon": "https://camo.githubusercontent.com/0e10b56a03b056a6e5fcf82a3cb3603188549a02c234b8e5426aaa11853e3069/68747470733a2f2f7261772e6769746875622e636f6d2f6d6f6e676f64622f6d6f6e676f636c692f6d61737465722f6d6f6e676f636c692e706e67"

--- a/build/package/send-slack-notification.sh
+++ b/build/package/send-slack-notification.sh
@@ -28,8 +28,15 @@ curl --header "Api-User:${evergreen_user:?}" \
        {
        	"title": "v'"${VERSION}"'",
        	"title_link": "https://github.com/mongodb/mongocli/releases/tag/v'"${VERSION}"'",
-       	"author_name": "MongoDB CLI",
+       	"author_name": "Release Page",
        	"fallback": "new release",
+	      "author_icon": "https://camo.githubusercontent.com/0e10b56a03b056a6e5fcf82a3cb3603188549a02c234b8e5426aaa11853e3069/68747470733a2f2f7261772e6769746875622e636f6d2f6d6f6e676f64622f6d6f6e676f636c692f6d61737465722f6d6f6e676f636c692e706e67"
+       },
+       {
+       	"title": "command.tgz",
+       	"title_link": "https://mongodb-mongocli-build.s3.amazonaws.com/mongocli-master/docs/'${revision-}'_'${created_at-}'/command.tgz",
+       	"author_name": "Generated Docs",
+       	"fallback": "new docs",
 	      "author_icon": "https://camo.githubusercontent.com/0e10b56a03b056a6e5fcf82a3cb3603188549a02c234b8e5426aaa11853e3069/68747470733a2f2f7261772e6769746875622e636f6d2f6d6f6e676f64622f6d6f6e676f636c692f6d61737465722f6d6f6e676f636c692e706e67"
        }]
      }'


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-94311

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Genertae docs on release and include on our internal announcement a link to it so docs can easily grave them 
