### PR TITLE
(DOCSP-17411): Add support for Atlas Gov

### DIFF
--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -280,7 +280,7 @@ Valid values: SCRAM-SHA-1|SCRAM-SHA-256`
 	AccessListType = `Type of access list entry.
 Valid values: cidrBlock|ipAddress|awsSecurityGroup`
 	Service = `Type of MongoDB service.
-Valid values: cloud|cloud-manager|ops-manager`
+Valid values: cloud|cloudgov|cloud-manager|ops-manager`
 	Provider = `Name of your cloud service provider.
 Valid values: AWS|AZURE|GCP.`
 	ClusterTypes = `Type of the cluster that you want to create.


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-17411)

Updates the description of the `--service` option in the help and generated docs to include the value `cloudgov`.
