### PR TITLE
CLOUDP-94849: Use cobra autocomplete instead of internal

### DIFF
--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -23,7 +23,6 @@ import (
 	cliconfig "github.com/mongodb/mongocli/internal/cli/config"
 	"github.com/mongodb/mongocli/internal/cli/iam"
 	"github.com/mongodb/mongocli/internal/cli/opsmanager"
-	"github.com/mongodb/mongocli/internal/cli/require"
 	"github.com/mongodb/mongocli/internal/config"
 	"github.com/mongodb/mongocli/internal/flag"
 	"github.com/mongodb/mongocli/internal/search"
@@ -31,36 +30,6 @@ import (
 	"github.com/mongodb/mongocli/internal/version"
 	"github.com/spf13/cobra"
 )
-
-func completionBuilder(root *cobra.Command) *cobra.Command {
-	completionCmd := &cobra.Command{
-		Use:   "completion <bash|zsh|fish|powershell>",
-		Args:  require.ExactValidArgs(1),
-		Short: "Generate shell completion scripts",
-		Long: `Generate shell completion scripts for MongoDB CLI commands.
-The output of this command will be computer code and is meant to be saved to a
-file or immediately evaluated by an interactive shell.
-
-When installing MongoDB CLI through brew, it's possible that
-no additional shell configuration is necessary, see https://docs.brew.sh/Shell-Completion.`,
-		ValidArgs: []string{"bash", "zsh", "powershell", "fish"},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			switch args[0] {
-			case "bash":
-				return root.GenBashCompletion(cmd.OutOrStdout())
-			case "zsh":
-				return root.GenZshCompletion(cmd.OutOrStdout())
-			case "powershell":
-				return root.GenPowerShellCompletion(cmd.OutOrStdout())
-			case "fish":
-				return root.GenFishCompletion(cmd.OutOrStdout(), true)
-			default:
-				return fmt.Errorf("unsupported shell type %q", args[0])
-			}
-		},
-	}
-	return completionCmd
-}
 
 // rootBuilder conditionally adds children commands as needed.
 // This is important in particular for Atlas as it dynamically sets flags for cluster creation and
@@ -102,7 +71,6 @@ func Builder(profile *string, argsWithoutProg []string) *cobra.Command {
 		cloudmanager.Builder(),
 		opsmanager.Builder(),
 		iam.Builder(),
-		completionBuilder(rootCmd),
 	)
 
 	rootCmd.PersistentFlags().StringVarP(profile, flag.Profile, flag.ProfileShort, "", usage.Profile)

--- a/internal/cli/root/builder_test.go
+++ b/internal/cli/root/builder_test.go
@@ -31,70 +31,70 @@ func TestBuilder(t *testing.T) {
 	}{
 		{
 			name: "atlas",
-			want: 6,
+			want: 5,
 			args: args{
 				argsWithoutProg: []string{"atlas"},
 			},
 		},
 		{
 			name: "ops-manager",
-			want: 5,
+			want: 4,
 			args: args{
 				argsWithoutProg: []string{"ops-manager"},
 			},
 		},
 		{
 			name: "cloud-manager",
-			want: 5,
+			want: 4,
 			args: args{
 				argsWithoutProg: []string{"cloud-manager"},
 			},
 		},
 		{
 			name: "ops-manager alias",
-			want: 5,
+			want: 4,
 			args: args{
 				argsWithoutProg: []string{"om"},
 			},
 		},
 		{
 			name: "cloud-manager alias",
-			want: 5,
+			want: 4,
 			args: args{
 				argsWithoutProg: []string{"cm"},
 			},
 		},
 		{
 			name: "iam",
-			want: 5,
+			want: 4,
 			args: args{
 				argsWithoutProg: []string{"iam"},
 			},
 		},
 		{
 			name: "empty",
-			want: 6,
+			want: 5,
 			args: args{
 				argsWithoutProg: []string{},
 			},
 		},
 		{
 			name: "autocomplete",
-			want: 6,
+			want: 5,
 			args: args{
 				argsWithoutProg: []string{"__complete"},
 			},
 		},
 		{
 			name: "completion",
-			want: 6,
+			want: 5,
 			args: args{
 				argsWithoutProg: []string{"completion"},
 			},
 		},
 		{
 			name: "--version",
-			want: 6,
+			want: 5,
 			args: args{
 				argsWithoutProg: []string{"completion"},
 			},


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-94849

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

With cobra 1.2.0 the completion command is now automagically generated we don't need to do it ourselves 