### PR TITLE
CLOUDP-95949: Stop using go-homedir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-test/deep v1.0.7
 	github.com/golang/mock v1.6.0
 	github.com/mattn/go-isatty v0.0.13
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mongodb-forks/digest v1.0.2
 	github.com/mongodb-labs/cobra2snooty v0.2.2
 	github.com/openlyinc/pointy v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,6 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/internal/config/home.go
+++ b/internal/config/home.go
@@ -17,15 +17,13 @@ package config
 import (
 	"fmt"
 	"os"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 func configHome() (string, error) {
 	if home := os.Getenv("XDG_CONFIG_HOME"); home != "" {
 		return home, nil
 	}
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 
 	if err != nil {
 		return "", err

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestConfig_configHome(t *testing.T) {
 	t.Run("with XDG_CONFIG_HOME", func(t *testing.T) {
-		xdgHome := "my_config"
+		const xdgHome = "my_config"
 		_ = os.Setenv("XDG_CONFIG_HOME", xdgHome)
 		home, err := configHome()
 		if err != nil {
@@ -35,13 +35,13 @@ func TestConfig_configHome(t *testing.T) {
 		_ = os.Unsetenv("XDG_CONFIG_HOME")
 	})
 	t.Run("without XDG_CONFIG_HOME", func(t *testing.T) {
-		_ = os.Setenv("HOME", ".")
 		home, err := configHome()
 		if err != nil {
 			t.Fatalf("configHome() unexpected error: %v", err)
 		}
-		if home != "./.config" {
-			t.Errorf("configHome() = %s; want './.config'", home)
+		osHome, _ := os.UserHomeDir()
+		if home != osHome+"/.config" {
+			t.Errorf("configHome() = %s; want '%s/.config'", home, osHome)
 		}
 	})
 }

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -19,8 +19,6 @@ package config
 import (
 	"os"
 	"testing"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 func TestConfig_configHome(t *testing.T) {
@@ -37,7 +35,6 @@ func TestConfig_configHome(t *testing.T) {
 		_ = os.Unsetenv("XDG_CONFIG_HOME")
 	})
 	t.Run("without XDG_CONFIG_HOME", func(t *testing.T) {
-		homedir.DisableCache = true
 		_ = os.Setenv("HOME", ".")
 		home, err := configHome()
 		if err != nil {
@@ -46,6 +43,5 @@ func TestConfig_configHome(t *testing.T) {
 		if home != "./.config" {
 			t.Errorf("configHome() = %s; want './.config'", home)
 		}
-		homedir.DisableCache = false
 	})
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-95949

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Go has now (since 1.12) native support for this without using cgo