### PR TITLE
CLOUDP-96279: Improve arg validation to show number of given args

### DIFF
--- a/internal/cli/require/require.go
+++ b/internal/cli/require/require.go
@@ -39,10 +39,11 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != n {
 			return fmt.Errorf(
-				"%q requires %d %s\n\nUsage:  %s",
+				"%q requires %d %s, received %d\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,
 				pluralize("argument", n),
+				len(args),
 				cmd.UseLine(),
 			)
 		}
@@ -66,10 +67,11 @@ func MaximumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) > n {
 			return fmt.Errorf(
-				"%q accepts at most %d %s\n\nUsage:  %s",
+				"%q accepts at most %d %s, received %d\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,
 				pluralize("argument", n),
+				len(args),
 				cmd.UseLine(),
 			)
 		}
@@ -82,10 +84,11 @@ func MinimumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) < n {
 			return fmt.Errorf(
-				"%q requires at least %d %s\n\nUsage:  %s",
+				"%q requires at least %d %s, received %d\n\nUsage:  %s",
 				cmd.CommandPath(),
 				n,
 				pluralize("argument", n),
+				len(args),
 				cmd.UseLine(),
 			)
 		}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-96279

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

This came from a ticket where users were inadvertently passing more than one parameter and not being aware of this caused them to open the ticket 