### PR TITLE
rfc: use embed for templates

### DIFF
--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -15,6 +15,8 @@
 package alerts
 
 import (
+	_ "embed"
+
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/require"
 	"github.com/mongodb/mongocli/internal/config"
@@ -39,9 +41,8 @@ func (opts *ListOpts) initStore() error {
 	return err
 }
 
-var listTemplate = `ID	TYPE	STATUS{{range .Results}}
-{{.ID}}	{{.EventTypeName}}	{{.Status}}{{end}}
-`
+//go:embed list.tmpl
+var listTemplate string
 
 func (opts *ListOpts) Run() error {
 	listOpts := opts.newAlertsListOptions()

--- a/internal/cli/alerts/list.tmpl
+++ b/internal/cli/alerts/list.tmpl
@@ -1,0 +1,2 @@
+{{- /*gotype: go.mongodb.org/atlas/mongodbatlas.AlertsResponse*/ -}}ID	TYPE	STATUS{{range .Results}}
+{{.ID}}	{{.EventTypeName}}	{{.Status}}{{end}}


### PR DESCRIPTION
## Proposed changes

RFC: start using `embed` for output templates instead of plain strings