### PR TITLE
test: use t.Setenv instead of os.Setenv

### DIFF
--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -25,7 +25,7 @@ import (
 func TestConfig_configHome(t *testing.T) {
 	t.Run("with XDG_CONFIG_HOME", func(t *testing.T) {
 		const xdgHome = "my_config"
-		_ = os.Setenv("XDG_CONFIG_HOME", xdgHome)
+		t.Setenv("XDG_CONFIG_HOME", xdgHome)
 		home, err := configHome()
 		if err != nil {
 			t.Fatalf("configHome() unexpected error: %v", err)
@@ -33,7 +33,6 @@ func TestConfig_configHome(t *testing.T) {
 		if home != xdgHome {
 			t.Errorf("configHome() = %s; want '%s'", home, xdgHome)
 		}
-		_ = os.Unsetenv("XDG_CONFIG_HOME")
 	})
 	t.Run("without XDG_CONFIG_HOME", func(t *testing.T) {
 		home, err := configHome()

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -153,8 +153,8 @@ func TestCredentials(t *testing.T) {
 		// this function depends on the global config (globals are bad I know)
 		// the easiest way we have to test it is via ENV vars
 		viper.AutomaticEnv()
-		_ = os.Setenv("PUBLIC_API_KEY", "test")
-		_ = os.Setenv("PRIVATE_API_KEY", "test")
+		t.Setenv("PUBLIC_API_KEY", "test")
+		t.Setenv("PRIVATE_API_KEY", "test")
 
 		err := Credentials()
 		if err != nil {


### PR DESCRIPTION
## Proposed changes

Small test improvement

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

