### PR TITLE
CLOUDP-95673: Quickstart cluster creation confirmation

### DIFF
--- a/docs/command/mongocli-atlas-quickstart.txt
+++ b/docs/command/mongocli-atlas-quickstart.txt
@@ -46,6 +46,10 @@ Options
      - 
      - false
      - Run the Quickstart command with all the auto generated values to deploy and access an Atlas cluster.
+   * - --force
+     - 
+     - false
+     - Don't ask for confirmation.
    * - -h, --help
      - 
      - false

--- a/internal/cli/atlas/quickstart/cluster_setup.go
+++ b/internal/cli/atlas/quickstart/cluster_setup.go
@@ -27,9 +27,6 @@ import (
 )
 
 func (opts *Opts) createCluster() error {
-	if err := opts.askClusterOptions(); err != nil {
-		return err
-	}
 	if _, err := opts.store.CreateCluster(opts.newCluster()); err != nil {
 		return err
 	}

--- a/internal/cli/atlas/quickstart/confirm_cluster_setup.go
+++ b/internal/cli/atlas/quickstart/confirm_cluster_setup.go
@@ -17,6 +17,7 @@ package quickstart
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -26,32 +27,35 @@ func (opts *Opts) askConfirmConfigQuestion() error {
 		return nil
 	}
 
-	diskSize := uint64(0)
+	diskSize := 0.5
 	if opts.newCluster().DiskSizeGB != nil {
-		diskSize = uint64(*opts.newCluster().DiskSizeGB)
+		diskSize = *opts.newCluster().DiskSizeGB
 	}
-
 	fmt.Printf(`
 [Summary of changes]
 Name:			%s
 Tier:			%s
-Disk Size (GB):		%d
+Cloud Provider:		%s
+Region:			%s
+Disk Size (GiB):	%.1f
 User:			%s
 Ip Address:		%s
 `,
 		opts.ClusterName,
 		opts.tier,
+		opts.Provider,
+		opts.Region,
 		diskSize,
 		opts.DBUsername,
-		opts.IPAddresses)
+		strings.Join(opts.IPAddresses, ", "),
+	)
 
-	confirmCreate := false
 	q := newClusterCreateConfirm(opts.ClusterName)
-	if err := survey.AskOne(q, &confirmCreate); err != nil {
+	if err := survey.AskOne(q, &opts.Confirm); err != nil {
 		return err
 	}
 
-	if !confirmCreate {
+	if !opts.Confirm {
 		return errors.New("user-aborted. Not creating cluster")
 	}
 	return nil

--- a/internal/cli/atlas/quickstart/confirm_cluster_setup.go
+++ b/internal/cli/atlas/quickstart/confirm_cluster_setup.go
@@ -1,0 +1,54 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quickstart
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+func (opts *Opts) askConfirmConfigQuestion() error {
+	if opts.Confirm {
+		return nil
+	}
+
+	diskSize := uint64(*opts.newCluster().DiskSizeGB)
+	fmt.Printf(`
+[Summary of changes]
+Name:			%s
+Tier:			%s
+Disk Size (GB):		%d
+User:			%s
+Ip Address:		%s
+`,
+		opts.ClusterName,
+		opts.tier,
+		diskSize,
+		opts.DBUsername,
+		opts.IPAddresses)
+
+	confirmCreate := false
+	q := newClusterCreateConfirm(opts.ClusterName)
+	if err := survey.AskOne(q, &confirmCreate); err != nil || !opts.runMongoShell {
+		return err
+	}
+
+	if !confirmCreate {
+		return errors.New("user-aborted. Not creating cluster")
+	}
+	return nil
+}

--- a/internal/cli/atlas/quickstart/confirm_cluster_setup.go
+++ b/internal/cli/atlas/quickstart/confirm_cluster_setup.go
@@ -31,6 +31,19 @@ func (opts *Opts) askConfirmConfigQuestion() error {
 	if opts.newCluster().DiskSizeGB != nil {
 		diskSize = *opts.newCluster().DiskSizeGB
 	}
+
+	const noMsg = "No"
+	const yesMsg = "Yes"
+	loadSampleData := yesMsg
+	if opts.SkipSampleData {
+		loadSampleData = noMsg
+	}
+
+	runMongoShell := noMsg
+	if opts.runMongoShell {
+		runMongoShell = yesMsg
+	}
+
 	fmt.Printf(`
 [Summary of changes]
 Cluster Name:				%s
@@ -40,6 +53,8 @@ Region:					%s
 Cluster Disk Size (GiB):		%.1f
 Database Username:			%s
 Allow connections from (IP Address):	%s
+Load sample data:			%s
+Open shell:				%s
 `,
 		opts.ClusterName,
 		opts.tier,
@@ -48,6 +63,8 @@ Allow connections from (IP Address):	%s
 		diskSize,
 		opts.DBUsername,
 		strings.Join(opts.IPAddresses, ", "),
+		loadSampleData,
+		runMongoShell,
 	)
 
 	q := newClusterCreateConfirm(opts.ClusterName)

--- a/internal/cli/atlas/quickstart/confirm_cluster_setup.go
+++ b/internal/cli/atlas/quickstart/confirm_cluster_setup.go
@@ -33,13 +33,13 @@ func (opts *Opts) askConfirmConfigQuestion() error {
 	}
 	fmt.Printf(`
 [Summary of changes]
-Name:			%s
-Tier:			%s
-Cloud Provider:		%s
-Region:			%s
-Disk Size (GiB):	%.1f
-User:			%s
-Ip Address:		%s
+Cluster Name:				%s
+Cluster Tier:				%s
+Cloud Provider:				%s
+Region:					%s
+Cluster Disk Size (GiB):		%.1f
+Database Username:			%s
+Allow connections from (IP Address):	%s
 `,
 		opts.ClusterName,
 		opts.tier,

--- a/internal/cli/atlas/quickstart/confirm_cluster_setup.go
+++ b/internal/cli/atlas/quickstart/confirm_cluster_setup.go
@@ -26,7 +26,11 @@ func (opts *Opts) askConfirmConfigQuestion() error {
 		return nil
 	}
 
-	diskSize := uint64(*opts.newCluster().DiskSizeGB)
+	diskSize := uint64(0)
+	if opts.newCluster().DiskSizeGB != nil {
+		diskSize = uint64(*opts.newCluster().DiskSizeGB)
+	}
+
 	fmt.Printf(`
 [Summary of changes]
 Name:			%s
@@ -43,7 +47,7 @@ Ip Address:		%s
 
 	confirmCreate := false
 	q := newClusterCreateConfirm(opts.ClusterName)
-	if err := survey.AskOne(q, &confirmCreate); err != nil || !opts.runMongoShell {
+	if err := survey.AskOne(q, &confirmCreate); err != nil {
 		return err
 	}
 

--- a/internal/cli/atlas/quickstart/prompt.go
+++ b/internal/cli/atlas/quickstart/prompt.go
@@ -139,3 +139,10 @@ func newProfileDocQuestionOpenBrowser() survey.Prompt {
 		Default: true,
 	}
 }
+
+func newClusterCreateConfirm(clusterName string) survey.Prompt {
+	return &survey.Confirm{
+		Message: fmt.Sprintf("Do you want to create a new cluster %s with the following settings?", clusterName),
+		Default: true,
+	}
+}

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -381,6 +381,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.SkipSampleData, flag.SkipSampleData, false, usage.SkipSampleData)
 	cmd.Flags().BoolVar(&opts.SkipMongosh, flag.SkipMongosh, false, usage.SkipMongosh)
 	cmd.Flags().BoolVarP(&opts.defaultValue, flag.Default, "Y", false, usage.QuickstartDefault)
+	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -90,6 +90,7 @@ type Opts struct {
 	runMongoShell       bool
 	mongoShellInstalled bool
 	defaultValue        bool
+	Confirm             bool
 	store               store.AtlasClusterQuickStarter
 }
 
@@ -102,13 +103,9 @@ func (opts *Opts) initStore() error {
 func (opts *Opts) Run() error {
 	fmt.Print(quickstartTemplateIntro)
 
-	if err := opts.createCluster(); err != nil {
+	if err := opts.askClusterOptions(); err != nil {
 		return err
 	}
-
-	fmt.Printf(`
-We are deploying %s...
-`, opts.ClusterName)
 
 	if err := opts.askSampleDataQuestion(); err != nil {
 		return err
@@ -123,6 +120,15 @@ We are deploying %s...
 	}
 
 	if err := opts.askMongoShellQuestion(); err != nil {
+		return err
+	}
+
+	if err := opts.askConfirmConfigQuestion(); err != nil {
+		return err
+	}
+
+	fmt.Printf(`We are deploying %s...`, opts.ClusterName)
+	if err := opts.createCluster(); err != nil {
 		return err
 	}
 

--- a/internal/cli/atlas/quickstart/quick_start_test.go
+++ b/internal/cli/atlas/quickstart/quick_start_test.go
@@ -53,6 +53,7 @@ func TestQuickstartOpts_Run(t *testing.T) {
 		Provider:       "AWS",
 		SkipMongosh:    true,
 		SkipSampleData: true,
+		Confirm:        true,
 	}
 
 	projectIPAccessList := opts.newProjectIPAccessList()


### PR DESCRIPTION
## Proposed changes
* Confirm before makign a cluster with quickstart
* Add summary of changes before creating cluster

_Jira ticket:_ CLOUDP-95673

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
Command:
```
bin/mongocli atlas quickstart --profile=atlas-dev --tier M0
You are creating a new Atlas cluster and enabling access to it.

Press [Enter] to use the default values.

Enter [?] on any option to get help.

[Set up your Atlas cluster]
? Cluster Name [This can't be changed later] Quickstart-1632214919
? Cloud Provider AWS
? Cloud Provider Region US_EAST_1
? Do you want to load sample data into Quickstart-1632214919? No

[Set up your database authentication access details]
? Database User Username Quickstart-1632214919
? Database User Password [Press Enter to use an auto-generated password '<REDACTED>'] <REDACTED>

[Set up your database network access details]
? Access List Entry [Press Enter to use your public IP address '109.255.179.192'] 1.2.3.4,5.6.7.8

[Connect to Quickstart-1632155644]
? Do you want to access Quickstart-1632155644 with MongoDB Shell? No

[Summary of changes]
Cluster Name:				Quickstart-1632214919
Cluster Tier:				M0
Cloud Provider:				AWS
Region:					US_EAST_1
Cluster Disk Size (GiB):		0.5
Database Username:			Quickstart-1632214919
Allow connections from (IP Address):	1.2.3.4, 5.6.7.8
Load sample data:			No
Open shell:				No
? Do you want to create a new cluster Quickstart-1632155644 with the following settings? No
Error: user-aborted. Not creating cluster
```

Select create cluster:
```
? Do you want to create a new cluster Quickstart-1632155677 with the following settings? Yes
We are deploying Quickstart-1632155677...
Creating your cluster... [It's safe to 'Ctrl + C']
\
```
Cluster being created:
![image](https://user-images.githubusercontent.com/4273411/134040197-1a274545-9cdd-4b89-a32f-cc6030f18eb8.png)
