### PR TITLE
fix: add missing commit info to msi windows package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     goos: [darwin]
     goarch: [amd64,arm64]
     hooks:
-      # This will notirize Apple binaries and replace goreleaser bins with the notarized ones
+      # This will notarize Apple binaries and replace goreleaser bins with the notarized ones
       post: ./build/package/mac_notarize.sh
   - <<: *build_defaults
     id: linux

--- a/build/package/generate-msi.sh
+++ b/build/package/generate-msi.sh
@@ -26,7 +26,10 @@ go-msi check-env
 SOURCE_FILES=./cmd/mongocli
 
 VERSION=$(git describe | cut -d "v" -f 2)
+COMMIT=$(git log -n1 --format=format:"%H")
 
-env GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X github.com/mongodb/mongocli/internal/version.Version=${VERSION}" -o ./bin/mongocli.exe "${SOURCE_FILES}"
+env GOOS=windows GOARCH=amd64 go build \
+  -ldflags "-s -w -X github.com/mongodb/mongocli/internal/version.Version=${VERSION} -X github.com/mongodb/mongocli/internal/version.GitCommit=${COMMIT}" \
+  -o ./bin/mongocli.exe "${SOURCE_FILES}"
 
 go-msi make --msi "dist/mongocli_${VERSION}_windows_x86_64.msi" --version "${VERSION}"


### PR DESCRIPTION
## Proposed changes

Add missing commit info to msi windows package

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

