### PR TITLE
CLOUDP-108533: Use correct arg validation for owner creation

### DIFF
--- a/docs/command/mongocli-ops-manager-owner-create.txt
+++ b/docs/command/mongocli-ops-manager-owner-create.txt
@@ -63,10 +63,6 @@ Options
      - string
      - false
      - User’s password.
-   * - --whitelistIp
-     - strings
-     - false
-     - IP addresses to add to the new user’s access list.
 
 Inherited Options
 -----------------

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -53,7 +53,7 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas alerts config(s) create
+// CreateBuilder mongocli atlas alerts config(s) create
 //	[--event event]
 //	[--enabled enabled]
 //	[--matcherField fieldName --matcherOperator operator --matcherValue value]

--- a/internal/cli/opsmanager/owner/create.go
+++ b/internal/cli/opsmanager/owner/create.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/cli/require"
 	"github.com/mongodb/mongocli/internal/config"
 	"github.com/mongodb/mongocli/internal/flag"
 	"github.com/mongodb/mongocli/internal/store"
@@ -95,14 +96,14 @@ func (opts *CreateOpts) Prompt() error {
 	return survey.AskOne(prompt, &opts.password)
 }
 
-// mongocli ops-manager owner create --email username --password password --firstName firstName --lastName lastName --accessListIp <IP>.
+// CreateBuilder mongocli ops-manager owner create --email username --password password --firstName firstName --lastName lastName --accessListIp <IP>.
 func CreateBuilder() *cobra.Command {
 	opts := new(CreateOpts)
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create the first user for Ops Manager.",
 		Long:  "Create the first user for Ops Manager. Use this command to automate Ops Manager Installations.",
-		Args:  cobra.OnlyValidArgs,
+		Args:  require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(
 				opts.initStore(cmd.Context()),
@@ -123,8 +124,8 @@ func CreateBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.firstName, flag.FirstName, "", usage.FirstName)
 	cmd.Flags().StringVar(&opts.lastName, flag.LastName, "", usage.LastName)
 	cmd.Flags().StringSliceVar(&opts.accessIps, flag.AccessListIP, []string{}, usage.AccessListIps)
-	_ = cmd.Flags().MarkDeprecated(flag.WhitelistIP, fmt.Sprintf("please use --%s instead", flag.AccessListIP))
 	cmd.Flags().StringSliceVar(&opts.accessIps, flag.WhitelistIP, []string{}, usage.AccessListIps)
+	_ = cmd.Flags().MarkDeprecated(flag.WhitelistIP, fmt.Sprintf("please use --%s instead", flag.AccessListIP))
 
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-108533

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if a new command or e2e test has been added)
- [x] I have run `make fmt` and formatted my code

Owner creation takes no arg so `cobra.OnlyValidArgs` is not correct, we should use `require.NoArgs`
