### PR TITLE
CLOUDP-110092: [MongoCLI] update macOs service to v3.1.0 and use env variables instead of flags for the creds

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -327,8 +327,8 @@ functions:
           export PATH="./bin:${go_bin}:$PATH"
           export GITHUB_TOKEN=${github_token}
           export NOTARY_SERVICE_URL=${notary_service_url}
-          export NOTARY_SERVICE_KEY_ID=${notary_service_key_id}
-          export NOTARY_SERVICE_SECRET=${notary_service_secret}
+          export MACOS_NOTARY_KEY=${notary_service_key_id}
+          export MACOS_NOTARY_SECRET=${notary_service_secret}
 
           # avoid race conditions on the notarization step by using `-p 1`
           ${goreleaser_cmd|goreleaser --rm-dist --snapshot -p 1}

--- a/build/package/mac_notarize.sh
+++ b/build/package/mac_notarize.sh
@@ -26,8 +26,6 @@ if [[ -f "./dist/macos_darwin_amd64/bin/mongocli" && -f "./dist/macos_darwin_arm
   ./darwin_amd64/macnotary \
       -f ./dist/mongocli_amd64_arm64_bin.zip \
       -m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
-      -s "${NOTARY_SERVICE_SECRET:?}" \
-      -k "${NOTARY_SERVICE_KEY_ID:?}"  \
       -b com.mongodb.mongocli \
       -o ./dist/mongocli_macos_signed.zip
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-110092

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
