### PR TITLE
Fix no Capacity error in private endpoint e2e tests

### DIFF
--- a/e2e/atlas/private_endpoint_test.go
+++ b/e2e/atlas/private_endpoint_test.go
@@ -32,21 +32,10 @@ var regionsAWS = []string{
 	"us-east-1",
 	"us-east-2",
 	"us-west-1",
-	"us-west-2",
 	"ca-central-1",
 	"sa-east-1",
-	"eu-north-1",
 	"eu-west-1",
-	"eu-west-2",
-	"eu-west-3",
 	"eu-central-1",
-	"me-south-1",
-	"ap-northeast-1",
-	"ap-northeast-2",
-	"ap-south-1",
-	"ap-southeast-1",
-	"ap-southeast-2",
-	"ap-east-1",
 }
 
 func TestPrivateEndpointsAWS(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
This PR removes most of the AWS regions used by aws private endpoint e2e tests. We keep only the ones that we are sure to work on cloud-dev.

```
[2022/01/21 11:06:56.978] === RUN   TestPrivateEndpointsAWS/Create
 [2022/01/21 11:06:56.978]     private_endpoint_test.go:78:
 [2022/01/21 11:06:56.978]         	Error Trace:	private_endpoint_test.go:78
 [2022/01/21 11:06:56.978]         	Error:      	Received unexpected error:
 [2022/01/21 11:06:56.978]         	            	exit status 1
 [2022/01/21 11:06:56.978]         	Test:       	TestPrivateEndpointsAWS/Create
 [2022/01/21 11:06:56.978]         	Messages:   	Error: POST https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/61ea93cf8206834ad49a9228/privateEndpoint/endpointService: 400 (request "ATLAS_GENERAL_ERROR") Reason: No Capacity.
 [2022/01/21 11:06:56.978] === CONT  TestPrivateEndpointsAWS
 [2022/01/21 11:06:56.978]     private_endpoint_test.go:85:
```
https://evergreen.mongodb.com/task_log_raw/mongocli_master_e2e_atlas_networking_atlas_private_endpoint_e2e_fcbbb6f233144f7299e218525d77f56afa9f50ec_22_01_21_10_44_03/0?type=T#L126