### PR TITLE
CLOUDP-110737: Update describe output to display groups

### DIFF
--- a/internal/cli/atlas/privateendpoints/gcp/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe.go
@@ -26,8 +26,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var describeTemplate = `ID	REGION	STATUS	ERROR
-{{.ID}}	{{.RegionName}}	{{.Status}}	{{.ErrorMessage}}
+var describeTemplate = `ID	GROUP NAME	REGION	STATUS	ERROR{{if .EndpointGroupNames}}{{range .EndpointGroupNames}}
+{{$.ID}}	{{.}}	{{$.RegionName}}	{{$.Status}}	{{$.ErrorMessage}}{{end}}{{else}}
+{{$.ID}}	N/A	{{$.RegionName}}	{{$.Status}}	{{$.ErrorMessage}}{{end}}
 `
 
 type DescribeOpts struct {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-110737](https://jira.mongodb.org/browse/CLOUDP-110737)

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

### Empty group names
```
➜ mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f304e9ce3d7f31fd3f4301
ID GROUP NAME REGION STATUS ERROR
61f304e9ce3d7f31fd3f4301 N/A CENTRAL_US AVAILABLE

➜  mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f304e9ce3d7f31fd3f4301 -o json
{
  "id": "61f304e9ce3d7f31fd3f4301",
  "status": "AVAILABLE",
  "regionName": "CENTRAL_US",
  "serviceAttachmentNames": [
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-0",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-1",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-2",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-3",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-4",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-central1/serviceAttachments/sa-us-central1-61dc598fd1f07c7b37ba425d-5"
  ]
}
```

###  1 endpoint group name

```
➜  mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f116ac6798d907014d4f8b
ID                         GROUP NAME          REGION       STATUS      ERROR
61f116ac6798d907014d4f8b   endpoint-1-bianca   EASTERN_US   AVAILABLE

➜  mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f116ac6798d907014d4f8b -o json
{
  "id": "61f116ac6798d907014d4f8b",
  "status": "AVAILABLE",
  "endpointGroupNames": [
    "endpoint-1-bianca"
  ],
  "regionName": "EASTERN_US",
  "serviceAttachmentNames": [
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-0",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-1",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-2",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-3",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-4",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-5"
  ]
}
```

### Multipole endpoints

```
➜  mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f116ac6798d907014d4f8b
ID                         GROUP NAME   REGION       STATUS      ERROR
61f116ac6798d907014d4f8b   test1        EASTERN_US   AVAILABLE
61f116ac6798d907014d4f8b   test2        EASTERN_US   AVAILABLE
61f116ac6798d907014d4f8b   test3        EASTERN_US   AVAILABLE
61f116ac6798d907014d4f8b   test4        EASTERN_US   AVAILABLE

➜  mongocli git:(CLOUDP-110737) ✗ mongocli atlas privateEndpoints gcp describe 61f116ac6798d907014d4f8b -o json
{
  "id": "61f116ac6798d907014d4f8b",
  "status": "AVAILABLE",
  "endpointGroupNames": [
    "test1",
    "test2",
    "test3",
    "test4"
  ],
  "regionName": "EASTERN_US",
  "serviceAttachmentNames": [
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-0",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-1",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-2",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-3",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-4",
    "projects/p-umsri3keckxuuhexj0cqlu31/regions/us-east1/serviceAttachments/sa-us-east1-61dc598fd1f07c7b37ba425d-5"
  ]
}
```
