### PR TITLE
fix: redact tokens when using config commands

### DIFF
--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -392,7 +392,7 @@ func (p *Profile) Map() map[string]string {
 		profileSettings[mongoShellPath] = p.MongoShellPath()
 	}
 	for k, v := range settings {
-		if k == privateAPIKey || k == publicAPIKey {
+		if k == privateAPIKey || k == publicAPIKey || k == authToken || k == refreshToken {
 			profileSettings[k] = "redacted"
 		} else {
 			profileSettings[k] = v


### PR DESCRIPTION
## Proposed changes

Redact tokens when using `mongocli config describe`

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

