### PR TITLE
CLOUDP-111671: [mongocli] Enable auth commands

### DIFF
--- a/docs/command/mongocli-auth-login.txt
+++ b/docs/command/mongocli-auth-login.txt
@@ -1,0 +1,76 @@
+.. _mongocli-auth-login:
+
+===================
+mongocli auth login
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Authenticate with MongoDB Atlas.
+
+Syntax
+------
+
+.. code-block::
+
+   mongocli auth login [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - --cm
+     - 
+     - false
+     - Log in to Cloud Manager.
+   * - --gov
+     - 
+     - false
+     - Log in to Atlas for Government.
+   * - -h, --help
+     - 
+     - false
+     - help for login
+   * - --noBrowser
+     - 
+     - false
+     - Don't try to open a browser session.
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   To start the interactive setup:
+   $ mongocli auth login
+
+

--- a/docs/command/mongocli-auth-logout.txt
+++ b/docs/command/mongocli-auth-logout.txt
@@ -12,7 +12,7 @@ mongocli auth logout
    :depth: 1
    :class: singlecol
 
-Log out the CLI.
+Log out of the CLI.
 
 Syntax
 ------

--- a/docs/command/mongocli-auth-logout.txt
+++ b/docs/command/mongocli-auth-logout.txt
@@ -1,0 +1,68 @@
+.. _mongocli-auth-logout:
+
+====================
+mongocli auth logout
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Log out the CLI.
+
+Syntax
+------
+
+.. code-block::
+
+   mongocli auth logout [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - --force
+     - 
+     - false
+     - If specified, skips asking for confirmation before proceeding with a requsted action.
+   * - -h, --help
+     - 
+     - false
+     - help for logout
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   To log out from the CLI:
+   $ mongocli auth logout
+
+

--- a/docs/command/mongocli-auth-whoami.txt
+++ b/docs/command/mongocli-auth-whoami.txt
@@ -1,0 +1,64 @@
+.. _mongocli-auth-whoami:
+
+====================
+mongocli auth whoami
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Verifies and displays information about your authentication state.
+
+Syntax
+------
+
+.. code-block::
+
+   mongocli auth whoami [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -h, --help
+     - 
+     - false
+     - help for whoami
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   See the logged account:
+   $ mongocli auth whoami
+
+

--- a/docs/command/mongocli-auth.txt
+++ b/docs/command/mongocli-auth.txt
@@ -1,0 +1,63 @@
+.. _mongocli-auth:
+
+=============
+mongocli auth
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Manage the CLI's authentication state.
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -h, --help
+     - 
+     - false
+     - help for auth
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Related Commands
+----------------
+
+* :ref:`mongocli-auth-login` - Authenticate with MongoDB Atlas.
+* :ref:`mongocli-auth-logout` - Log out the CLI.
+* :ref:`mongocli-auth-whoami` - Verifies and displays information about your authentication state.
+
+
+.. toctree::
+   :titlesonly:
+
+   login </command/mongocli-auth-login>
+   logout </command/mongocli-auth-logout>
+   whoami </command/mongocli-auth-whoami>
+

--- a/docs/command/mongocli-auth.txt
+++ b/docs/command/mongocli-auth.txt
@@ -50,7 +50,7 @@ Related Commands
 ----------------
 
 * :ref:`mongocli-auth-login` - Authenticate with MongoDB Atlas.
-* :ref:`mongocli-auth-logout` - Log out the CLI.
+* :ref:`mongocli-auth-logout` - Log out of the CLI.
 * :ref:`mongocli-auth-whoami` - Verifies and displays information about your authentication state.
 
 

--- a/docs/command/mongocli.txt
+++ b/docs/command/mongocli.txt
@@ -49,6 +49,7 @@ Related Commands
 ----------------
 
 * :ref:`mongocli-atlas` - Atlas operations.
+* :ref:`mongocli-auth` - Manage the CLI's authentication state.
 * :ref:`mongocli-cloud-manager` - MongoDB Cloud Manager operations.
 * :ref:`mongocli-completion` - Generate the autocompletion script for the specified shell
 * :ref:`mongocli-config` - Configure a profile to store access settings for your MongoDB deployment.
@@ -60,6 +61,7 @@ Related Commands
    :titlesonly:
 
    atlas </command/mongocli-atlas>
+   auth </command/mongocli-auth>
    cloud-manager </command/mongocli-cloud-manager>
    completion </command/mongocli-completion>
    config </command/mongocli-config>

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -68,7 +68,7 @@ func LogoutBuilder() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "Log out the CLI.",
+		Short: "Log out of the CLI.",
 		Example: `  To log out from the CLI:
   $ mongocli auth logout
 `,

--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/atlas"
+	"github.com/mongodb/mongocli/internal/cli/auth"
 	"github.com/mongodb/mongocli/internal/cli/cloudmanager"
 	cliconfig "github.com/mongodb/mongocli/internal/cli/config"
 	"github.com/mongodb/mongocli/internal/cli/iam"
@@ -89,10 +90,22 @@ func Builder(profile *string, argsWithoutProg []string) *cobra.Command {
 	if !hasArgs || search.StringInSlice(shouldIncludeAtlas, argsWithoutProg[0]) {
 		rootCmd.AddCommand(atlas.Builder())
 	}
+	// hidden shortcuts
+	loginCmd := auth.LoginBuilder()
+	loginCmd.Hidden = true
+	logoutCmd := auth.LogoutBuilder()
+	logoutCmd.Hidden = true
+	whoCmd := auth.WhoAmIBuilder()
+	whoCmd.Hidden = true
+
 	rootCmd.AddCommand(
 		cloudmanager.Builder(),
 		opsmanager.Builder(),
 		iam.Builder(),
+		auth.Builder(),
+		loginCmd,
+		logoutCmd,
+		whoCmd,
 	)
 
 	rootCmd.PersistentFlags().StringVarP(profile, flag.Profile, flag.ProfileShort, "", usage.Profile)

--- a/internal/cli/root/builder_test.go
+++ b/internal/cli/root/builder_test.go
@@ -39,70 +39,70 @@ func TestBuilder(t *testing.T) {
 	}{
 		{
 			name: "atlas",
-			want: 5,
+			want: 9,
 			args: args{
 				argsWithoutProg: []string{"atlas"},
 			},
 		},
 		{
 			name: "ops-manager",
-			want: 4,
+			want: 8,
 			args: args{
 				argsWithoutProg: []string{"ops-manager"},
 			},
 		},
 		{
 			name: "cloud-manager",
-			want: 4,
+			want: 8,
 			args: args{
 				argsWithoutProg: []string{"cloud-manager"},
 			},
 		},
 		{
 			name: "ops-manager alias",
-			want: 4,
+			want: 8,
 			args: args{
 				argsWithoutProg: []string{"om"},
 			},
 		},
 		{
 			name: "cloud-manager alias",
-			want: 4,
+			want: 8,
 			args: args{
 				argsWithoutProg: []string{"cm"},
 			},
 		},
 		{
 			name: "iam",
-			want: 4,
+			want: 8,
 			args: args{
 				argsWithoutProg: []string{"iam"},
 			},
 		},
 		{
 			name: "empty",
-			want: 5,
+			want: 9,
 			args: args{
 				argsWithoutProg: []string{},
 			},
 		},
 		{
 			name: "autocomplete",
-			want: 5,
+			want: 9,
 			args: args{
 				argsWithoutProg: []string{"__complete"},
 			},
 		},
 		{
 			name: "completion",
-			want: 5,
+			want: 9,
 			args: args{
 				argsWithoutProg: []string{"completion"},
 			},
 		},
 		{
 			name: "--version",
-			want: 5,
+			want: 9,
 			args: args{
 				argsWithoutProg: []string{"completion"},
 			},


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-111671

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Enables the auth set of commands and adds a couple of hidden shortcuts