### PR TITLE
CLOUDP-112072: Improve cli credential (jwt) handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tangzero/inflector v1.0.0
-	go.mongodb.org/atlas v0.14.1-0.20220202080947-4a7d97e77246
+	go.mongodb.org/atlas v0.14.1-0.20220208112622-89c55716021c
 	go.mongodb.org/ops-manager v0.34.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ go.etcd.io/etcd/api/v3 v3.5.1/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.1/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.1/go.mod h1:pMEacxZW7o8pg4CrFE7pquyCJJzZvkvdD2RibOCCCGs=
 go.mongodb.org/atlas v0.14.0/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
-go.mongodb.org/atlas v0.14.1-0.20220202080947-4a7d97e77246 h1:BkSHgSH3o6KawlMdsnR+XpZ/pCDbWK5secDmcUmytL0=
-go.mongodb.org/atlas v0.14.1-0.20220202080947-4a7d97e77246/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.14.1-0.20220208112622-89c55716021c h1:7bhmqXH09heZpHUsr2yHpks8LWAUy6BuoVLZVjot+Mc=
+go.mongodb.org/atlas v0.14.1-0.20220208112622-89c55716021c/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/ops-manager v0.34.0 h1:d8TgpJpPFeVLr+6HrAbbbYnKkdk+2JW6E20OBdgqXg8=
 go.mongodb.org/ops-manager v0.34.0/go.mod h1:85LPPdME1TFJ/Eau/IgOmy37YWGw1p/S8PBSME8ukXs=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/require"
 	"github.com/mongodb/mongocli/internal/config"
@@ -45,7 +44,7 @@ type Authenticator interface {
 
 type LoginConfig interface {
 	config.SetSaver
-	Access() (*jwt.Token, jwt.RegisteredClaims, error)
+	AccessTokenSubject() (string, error)
 }
 
 type loginOpts struct {
@@ -94,11 +93,11 @@ func (opts *loginOpts) Run(ctx context.Context) error {
 		return err
 	}
 	opts.SetUpAccess()
-	_, c, err := opts.config.Access()
+	s, err := opts.config.AccessTokenSubject()
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(opts.OutWriter, "Successfully logged in as %s.\n", c.Subject)
+	_, _ = fmt.Fprintf(opts.OutWriter, "Successfully logged in as %s.\n", s)
 	if opts.loginOnly {
 		return opts.config.Save()
 	}

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongocli/internal/mocks"
 	"github.com/mongodb/mongocli/internal/test"
@@ -98,7 +97,7 @@ func Test_loginOpts_Run(t *testing.T) {
 	mockConfig.EXPECT().Set("auth_token", "asdf").Times(1)
 	mockConfig.EXPECT().Set("refresh_token", "querty").Times(1)
 	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
-	mockConfig.EXPECT().Access().Return(nil, jwt.RegisteredClaims{Subject: "test@10gen.com"}, nil).Times(1)
+	mockConfig.EXPECT().AccessTokenSubject().Return("test@10gen.com", nil).Times(1)
 	mockConfig.EXPECT().Save().Return(nil).Times(1)
 	expectedOrgs := &atlas.Organizations{}
 	mockStore.EXPECT().Organizations(gomock.Any()).Return(expectedOrgs, nil).Times(0)

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -43,7 +43,7 @@ type ConfigDeleter interface {
 }
 
 type Revoker interface {
-	Revoke(context.Context, string, string) (*atlas.Response, error)
+	RevokeToken(context.Context, string, string) (*atlas.Response, error)
 }
 
 func (opts *logoutOpts) initFlow() error {
@@ -54,7 +54,7 @@ func (opts *logoutOpts) initFlow() error {
 
 func (opts *logoutOpts) Run(ctx context.Context) error {
 	// revoking a refresh token revokes the access token
-	if _, err := opts.flow.Revoke(ctx, config.RefreshToken(), "refresh_token"); err != nil {
+	if _, err := opts.flow.RevokeToken(ctx, config.RefreshToken(), "refresh_token"); err != nil {
 		return err
 	}
 
@@ -81,11 +81,11 @@ func LogoutBuilder() *cobra.Command {
 			if config.RefreshToken() == "" {
 				return errors.New("not logged in")
 			}
-			_, c, err := config.Access()
+			s, err := config.AccessTokenSubject()
 			if err != nil {
 				return err
 			}
-			opts.Entry = c.Subject
+			opts.Entry = s
 			if err := opts.PromptWithMessage("Are you sure you want to log out of account %s?"); err != nil {
 				return err
 			}

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -57,7 +57,7 @@ func Test_logoutOpts_Run(t *testing.T) {
 	ctx := context.TODO()
 	mockFlow.
 		EXPECT().
-		Revoke(ctx, gomock.Any(), gomock.Any()).
+		RevokeToken(ctx, gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		Times(1)
 	mockConfig.

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -48,14 +48,14 @@ func WhoAmIBuilder() *cobra.Command {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if config.AuthToken() == "" {
+			if config.AccessToken() == "" {
 				return errors.New("not logged in")
 			}
-			_, c, err := config.Access()
+			s, err := config.AccessTokenSubject()
 			if err != nil {
 				return err
 			}
-			opts.account = c.Subject
+			opts.account = s
 
 			return opts.Run()
 		},

--- a/internal/mocks/mock_login.go
+++ b/internal/mocks/mock_login.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	jwt "github.com/golang-jwt/jwt/v4"
 	gomock "github.com/golang/mock/gomock"
 	auth "go.mongodb.org/atlas/auth"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
@@ -92,20 +91,19 @@ func (m *MockLoginConfig) EXPECT() *MockLoginConfigMockRecorder {
 	return m.recorder
 }
 
-// Access mocks base method.
-func (m *MockLoginConfig) Access() (*jwt.Token, jwt.RegisteredClaims, error) {
+// AccessTokenSubject mocks base method.
+func (m *MockLoginConfig) AccessTokenSubject() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Access")
-	ret0, _ := ret[0].(*jwt.Token)
-	ret1, _ := ret[1].(jwt.RegisteredClaims)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "AccessTokenSubject")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// Access indicates an expected call of Access.
-func (mr *MockLoginConfigMockRecorder) Access() *gomock.Call {
+// AccessTokenSubject indicates an expected call of AccessTokenSubject.
+func (mr *MockLoginConfigMockRecorder) AccessTokenSubject() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Access", reflect.TypeOf((*MockLoginConfig)(nil).Access))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessTokenSubject", reflect.TypeOf((*MockLoginConfig)(nil).AccessTokenSubject))
 }
 
 // Save mocks base method.

--- a/internal/mocks/mock_logout.go
+++ b/internal/mocks/mock_logout.go
@@ -35,19 +35,19 @@ func (m *MockRevoker) EXPECT() *MockRevokerMockRecorder {
 	return m.recorder
 }
 
-// Revoke mocks base method.
-func (m *MockRevoker) Revoke(arg0 context.Context, arg1, arg2 string) (*mongodbatlas.Response, error) {
+// RevokeToken mocks base method.
+func (m *MockRevoker) RevokeToken(arg0 context.Context, arg1, arg2 string) (*mongodbatlas.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Revoke", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RevokeToken", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*mongodbatlas.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Revoke indicates an expected call of Revoke.
-func (mr *MockRevokerMockRecorder) Revoke(arg0, arg1, arg2 interface{}) *gomock.Call {
+// RevokeToken indicates an expected call of RevokeToken.
+func (mr *MockRevokerMockRecorder) RevokeToken(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revoke", reflect.TypeOf((*MockRevoker)(nil).Revoke), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockRevoker)(nil).RevokeToken), arg0, arg1, arg2)
 }
 
 // MockConfigDeleter is a mock of ConfigDeleter interface.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongocli/internal/config"
+	atlasauth "go.mongodb.org/atlas/auth"
 )
 
 type auth struct {
@@ -30,11 +31,11 @@ type auth struct {
 	token    string
 }
 
-func (a auth) RefreshToken() string {
-	return a.token
+func (a auth) Token() (*atlasauth.Token, error) {
+	return nil, nil
 }
 
-func (a auth) AuthToken() string {
+func (a auth) RefreshToken() string {
 	return a.token
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -97,8 +97,8 @@ var ErrMissingCredentials = errors.New("missing credentials")
 
 // Credentials validates public and private API keys have been set.
 func Credentials() error {
-	if config.AuthToken() != "" {
-		return nil
+	if t, err := config.Token(); t != nil {
+		return err
 	}
 	if config.PrivateAPIKey() != "" && config.PublicAPIKey() != "" {
 		return nil

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -162,7 +162,8 @@ func TestCredentials(t *testing.T) {
 		// this function depends on the global config (globals are bad I know)
 		// the easiest way we have to test it is via ENV vars
 		viper.AutomaticEnv()
-		t.Setenv("AUTH_TOKEN", "test")
+		t.Setenv("ACCESS_TOKEN", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+		t.Setenv("REFRESH_TOKEN", "test")
 		if err := Credentials(); err != nil {
 			t.Fatalf("Credentials() unexpected error %v\n", err)
 		}
@@ -223,7 +224,7 @@ func TestOptionalURL(t *testing.T) {
 	}{
 		{
 			name:    "valid",
-			val:     "http://test.com/",
+			val:     "https://test.com/",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-112072

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Depends on https://github.com/mongodb/go-client-mongodb-atlas/pull/277

- Encapsulate JWT parsing to only expose the subject (what we care)
- Refactor configuration to expose the Access struct from the atlas sdk so we can reuse the whole information when refreshing tokens 