### PR TITLE
CLOUDP-114507: [MongoCLI] mongocli config --service ops-manager is not adding ops_manager_url to config

### DIFF
--- a/internal/cli/atlas/config/init.go
+++ b/internal/cli/atlas/config/init.go
@@ -31,7 +31,7 @@ import (
 const atlas = "atlas"
 
 type initOpts struct {
-	cli.ConfigOpts
+	cli.DigestConfigOpts
 	gov bool
 }
 
@@ -109,6 +109,10 @@ func InitBuilder() *cobra.Command {
   To configure the tool to work with Atlas for Government
   $ atlas config init --gov
 `,
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			opts.OutWriter = cmd.OutOrStdout()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run(cmd.Context())
 		},

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -49,7 +48,6 @@ type LoginConfig interface {
 
 type loginOpts struct {
 	cli.DefaultSetterOpts
-	OutWriter      io.Writer
 	AccessToken    string
 	RefreshToken   string
 	isGov          bool
@@ -66,7 +64,7 @@ func (opts *loginOpts) initFlow() error {
 	return err
 }
 
-func (opts *loginOpts) SetUpAccess() {
+func (opts *loginOpts) SetOAuthUpAccess() {
 	switch {
 	case opts.isGov:
 		opts.Service = config.CloudGovService
@@ -95,7 +93,7 @@ func (opts *loginOpts) Run(ctx context.Context) error {
 	if err := opts.oauthFlow(ctx); err != nil {
 		return err
 	}
-	opts.SetUpAccess()
+	opts.SetOAuthUpAccess()
 	s, err := opts.config.AccessTokenSubject()
 	if err != nil {
 		return err
@@ -172,12 +170,12 @@ Your code will expire after %.0f minutes.
 
 func (opts *loginOpts) askOrg() error {
 	oMap, oSlice, err := opts.Orgs()
-	var orgID string
 	if err != nil || len(oSlice) == 0 {
 		return errors.New("no orgs")
 	}
 
 	p := prompt.NewOrgSelect(oSlice)
+	var orgID string
 	if err := survey.AskOne(p, &orgID); err != nil {
 		return err
 	}
@@ -187,12 +185,12 @@ func (opts *loginOpts) askOrg() error {
 
 func (opts *loginOpts) askProject() error {
 	pMap, pSlice, err := opts.Projects()
-	var projectID string
 	if err != nil || len(pSlice) == 0 {
 		return errors.New("no projects")
 	}
 
 	p := prompt.NewProjectSelect(pSlice)
+	var projectID string
 	if err := survey.AskOne(p, &projectID); err != nil {
 		return err
 	}

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -60,10 +60,10 @@ func Test_loginOpts_Run(t *testing.T) {
 	opts := &loginOpts{
 		flow:      mockFlow,
 		config:    mockConfig,
-		OutWriter: buf,
 		noBrowser: true,
 		loginOnly: true,
 	}
+	opts.OutWriter = buf
 	opts.Store = mockStore
 	expectedCode := &auth.DeviceCode{
 		UserCode:        "12345678",

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+// +build unit
+
+package config
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/test"
+)
+
+func TestBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		Builder(),
+		5,
+		[]string{flag.Service},
+	)
+}

--- a/internal/cli/config_opts.go
+++ b/internal/cli/config_opts.go
@@ -21,13 +21,13 @@ import (
 	"github.com/mongodb/mongocli/internal/validate"
 )
 
-type ConfigOpts struct {
+type DigestConfigOpts struct {
 	DefaultSetterOpts
 	PublicAPIKey  string
 	PrivateAPIKey string
 }
 
-func (opts *ConfigOpts) SetUpServiceAndKeys() {
+func (opts *DigestConfigOpts) SetUpServiceAndKeys() {
 	config.SetService(opts.Service)
 	if opts.PublicAPIKey != "" {
 		config.SetPublicAPIKey(opts.PublicAPIKey)
@@ -37,17 +37,24 @@ func (opts *ConfigOpts) SetUpServiceAndKeys() {
 	}
 }
 
+func (opts *DigestConfigOpts) SetUpDigestAccess() {
+	opts.SetUpServiceAndKeys()
+	if opts.OpsManagerURL != "" {
+		config.SetOpsManagerURL(opts.OpsManagerURL)
+	}
+}
+
 // AskProject will try to construct a select based on fetched projects.
 // If it fails or there are no projects to show we fallback to ask for project by ID.
-func (opts *ConfigOpts) AskProject() error {
+func (opts *DigestConfigOpts) AskProject() error {
 	pMap, pSlice, err := opts.Projects()
-	var projectID string
 	if err != nil || len(pSlice) == 0 {
 		p := prompt.NewProjectIDInput()
 		return survey.AskOne(p, &opts.ProjectID, survey.WithValidator(validate.OptionalObjectID))
 	}
 
 	p := prompt.NewProjectSelect(pSlice)
+	var projectID string
 	if err := survey.AskOne(p, &projectID); err != nil {
 		return err
 	}
@@ -57,15 +64,15 @@ func (opts *ConfigOpts) AskProject() error {
 
 // AskOrg will try to construct a select based on fetched organizations.
 // If it fails or there are no organizations to show we fallback to ask for org by ID.
-func (opts *ConfigOpts) AskOrg() error {
+func (opts *DigestConfigOpts) AskOrg() error {
 	oMap, oSlice, err := opts.Orgs()
-	var orgID string
 	if err != nil || len(oSlice) == 0 {
 		p := prompt.NewOrgIDInput()
 		return survey.AskOne(p, &opts.OrgID, survey.WithValidator(validate.OptionalObjectID))
 	}
 
 	p := prompt.NewOrgSelect(oSlice)
+	var orgID string
 	if err := survey.AskOne(p, &orgID); err != nil {
 		return err
 	}

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -43,6 +44,7 @@ type DefaultSetterOpts struct {
 	MongoShellPath string
 	Output         string
 	Store          ProjectOrgsLister
+	OutWriter      io.Writer
 }
 
 func (opts *DefaultSetterOpts) InitStore(ctx context.Context) error {

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -27,7 +27,7 @@ func CmdValidator(t *testing.T, subject *cobra.Command, nSubCommands int, flags 
 	t.Helper()
 	a := assert.New(t)
 	if len(subject.Commands()) != nSubCommands {
-		t.Errorf("Sub command count mismatch. Expected %d, got %d. Check the CmdValidator for your command.\n", len(subject.Commands()), nSubCommands)
+		t.Errorf("Sub command count mismatch. Expected %d, got %d. Check the CmdValidator for your command.\n", nSubCommands, len(subject.Commands()))
 	}
 	if len(flags) == 0 {
 		a.False(subject.HasAvailableFlags(), "expected command to not have flags but it does")


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-114507

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

I spent quite some time trying to add a test to avoid this happening again but can't say I have found a good way to do it, having to pass things from stdin to the commands makes it complicated 