### PR TITLE
Release Fix: Updated download center s3 bucket name

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -562,7 +562,7 @@ tasks:
           TOOL_NAME: ${tool_name}
       - func: "uninstall go-msi"
       - func: "upload dist"
-      - command: s3.put # TODO: we have to update the s3 bucket name to be ${tool_name} - CLOUDP-113712: WAITING FOR https://jira.mongodb.org/browse/WEBSITE-11811
+      - command: s3.put
         params:
           aws_key: ${download_center_aws_key}
           aws_secret: ${download_center_aws_secret}

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -568,11 +568,36 @@ tasks:
           aws_secret: ${download_center_aws_secret}
           local_files_include_filter:
             - src/github.com/mongodb/mongocli/dist/*.msi
-          remote_file: mongodb-atlas-cli/
+          remote_file: mongocli/
           bucket: downloads.mongodb.org
           permissions: public-read
           content_type: ${content_type|application/x-gzip}
           display_name: downloads-center-
+  - name: release_atlascli_msi
+    stepback: false
+    git_tag_only: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+    commands:
+      - func: "clone"
+      - func: "install go-msi"
+      - func: "generate msi"
+        vars:
+          TOOL_NAME: ${tool_name}
+      - func: "uninstall go-msi"
+      - func: "upload dist"
+#      - command: s3.put // TODO CLOUDP-113712: WAITING FOR https://jira.mongodb.org/browse/WEBSITE-11811
+#        params:
+#          aws_key: ${download_center_aws_key}
+#          aws_secret: ${download_center_aws_secret}
+#          local_files_include_filter:
+#            - src/github.com/mongodb/mongocli/dist/*.msi
+#          remote_file: mongocli/
+#          bucket: downloads.mongodb.org
+#          permissions: public-read
+#          content_type: ${content_type|application/x-gzip}
+#          display_name: downloads-center-
 
   ################################################################
   # Unstable Publish - AtlasCLI
@@ -1317,7 +1342,7 @@ buildvariants:
       go_bin: "c:\\golang\\go1.17/bin"
       tool_name: "atlascli"
     tasks:
-      - name: release_msi
+      - name: release_atlascli_msi
   - name: release_mongocli_publish_42
     display_name: "Publish MongoCLI yum/apt 4.2"
     run_on:

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -562,7 +562,7 @@ tasks:
           TOOL_NAME: ${tool_name}
       - func: "uninstall go-msi"
       - func: "upload dist"
-      - command: s3.put
+      - command: s3.put # TODO: we have to update the s3 bucket name to be ${tool_name} - CLOUDP-113712: WAITING FOR https://jira.mongodb.org/browse/WEBSITE-11811
         params:
           aws_key: ${download_center_aws_key}
           aws_secret: ${download_center_aws_secret}
@@ -573,32 +573,6 @@ tasks:
           permissions: public-read
           content_type: ${content_type|application/x-gzip}
           display_name: downloads-center-
-  - name: release_atlascli_msi
-    stepback: false
-    git_tag_only: true
-    depends_on:
-      - name: compile
-        variant: "code_health"
-    commands:
-      - func: "clone"
-      - func: "install go-msi"
-      - func: "generate msi"
-        vars:
-          TOOL_NAME: ${tool_name}
-      - func: "uninstall go-msi"
-      - func: "upload dist"
-#      - command: s3.put // TODO CLOUDP-113712: WAITING FOR https://jira.mongodb.org/browse/WEBSITE-11811
-#        params:
-#          aws_key: ${download_center_aws_key}
-#          aws_secret: ${download_center_aws_secret}
-#          local_files_include_filter:
-#            - src/github.com/mongodb/mongocli/dist/*.msi
-#          remote_file: mongocli/
-#          bucket: downloads.mongodb.org
-#          permissions: public-read
-#          content_type: ${content_type|application/x-gzip}
-#          display_name: downloads-center-
-
   ################################################################
   # Unstable Publish - AtlasCLI
   # RPM Distros
@@ -1342,7 +1316,7 @@ buildvariants:
       go_bin: "c:\\golang\\go1.17/bin"
       tool_name: "atlascli"
     tasks:
-      - name: release_atlascli_msi
+      - name: release_msi
   - name: release_mongocli_publish_42
     display_name: "Publish MongoCLI yum/apt 4.2"
     run_on:


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

Atas msi release task failed because we were adding the msi file to the wrong folder in the download center s3 bucket ([error](https://evergreen.mongodb.com/task_log_raw/mongocli_master_release_atlascli_msi_release_msi__atlascli_v0.0.1_22_03_04_16_11_31/0?type=T#L123)).

This PR adds the atlascli msi file in the same mongocli folder in the download center s3 bucket
