### PR TITLE
Release Fix: Upload atlascli binaries in the s3 bucket

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -528,23 +528,23 @@ tasks:
         vars:
           FEED_FILE_NAME: mongodb-atlas-cli.json
           TOOL_NAME: atlascli
-#      - func: "upload dist" TODO CLOUDP-113712: WAITING FOR https://jira.mongodb.org/browse/WEBSITE-11811
-#      - command: s3.put
-#        params:
-#          aws_key: ${download_center_aws_key}
-#          aws_secret: ${download_center_aws_secret}
-#          local_files_include_filter:
-#            - src/github.com/mongodb/mongocli/dist/*.tar.gz
-#            - src/github.com/mongodb/mongocli/dist/*.zip
-#            - src/github.com/mongodb/mongocli/dist/*.deb
-#            - src/github.com/mongodb/mongocli/dist/*.rpm
-#            - src/github.com/mongodb/mongocli/dist/*.tgz
-#            - src/github.com/mongodb/mongocli/dist/*.json
-#          remote_file: mongocli/
-#          bucket: downloads.mongodb.org
-#          permissions: public-read
-#          content_type: ${content_type|application/x-gzip}
-#          display_name: downloads-center-
+      - func: "upload dist"
+      - command: s3.put
+        params:
+          aws_key: ${download_center_aws_key}
+          aws_secret: ${download_center_aws_secret}
+          local_files_include_filter:
+            - src/github.com/mongodb/mongocli/dist/*.tar.gz
+            - src/github.com/mongodb/mongocli/dist/*.zip
+            - src/github.com/mongodb/mongocli/dist/*.deb
+            - src/github.com/mongodb/mongocli/dist/*.rpm
+            - src/github.com/mongodb/mongocli/dist/*.tgz
+            - src/github.com/mongodb/mongocli/dist/*.json
+          remote_file: mongocli/
+          bucket: downloads.mongodb.org
+          permissions: public-read
+          content_type: ${content_type|application/x-gzip}
+          display_name: downloads-center-
       - func: "send slack notification"
         vars:
           TOOL_NAME: atlascli


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->


<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
Issue: I have previously commented out the step where we were uploading the atlascli binaries in the download center s3 bucket because I thought we had to wait for the go-ahead from the marketing team. Long story short, we (APIx) are responsible for the mongocli folder on the download center s3 bucket so as long as we provide the `download_center.json` file with correct paths to the binaries to the marketing team, we are granted.

This PR removes the commented step in the atlascli release process.